### PR TITLE
Mouse notebook, comments

### DIFF
--- a/notebooks/Mouse_Brain_Broad.ipynb
+++ b/notebooks/Mouse_Brain_Broad.ipynb
@@ -111,7 +111,7 @@
     "k = 50\n",
     "num_times = 10\n",
     "\n",
-    "gpus = 1\n",
+    "gpus = None\n",
     "tpu_cores = None\n",
     "precision = 32\n",
     "\n",
@@ -549,7 +549,7 @@
    "source": [
     "%%time\n",
     "for tryy in range(1,num_times+1):\n",
-    "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1)\n",
+    "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1, num_cores)\n",
     "    all_markers = np.arange(X.shape[1])\n",
     "    X_train = X[np.concatenate([train_indices, val_indices]), :]\n",
     "    y_train = y[np.concatenate([train_indices, val_indices])]\n",
@@ -601,7 +601,7 @@
     "    # to stop those methods from using the same global seed over and over.\n",
     "    np.random.seed(possible_seeds[seed_index])\n",
     "    seed_index += 1\n",
-    "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1)\n",
+    "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1, num_workers = num_cores)\n",
     "    train_X_y = adata_snrna_raw[np.concatenate([train_indices, val_indices]), :]\n",
     "    sm = smashpy.smashpy()\n",
     "    np.random.seed(np.random.randint(low=10, high = 1000))\n",
@@ -759,7 +759,7 @@
     "\n",
     "    model = VAE_l1_diag(input_size, hidden_layer_size, z_size, batch_norm = batch_norm)\n",
     "    tmp_path = model_save_path + 'l1_vae_{}.ckpt'.format(tryy)\n",
-    "    train_save_model(model, train_dataloader, val_dataloader, tmp_path, gpus=1, min_epochs = 25, max_epochs = 100, auto_lr = True, max_lr = 0.00001, early_stopping_patience = 10, \n",
+    "    train_save_model(model, train_dataloader, val_dataloader, tmp_path, gpus=gpus, min_epochs = 25, max_epochs = 100, auto_lr = True, max_lr = 0.00001, early_stopping_patience = 10, \n",
     "                     lr_explore_mode = 'linear', num_lr_rates = 500)\n",
     "    l1_markers = model.markers(feature_std = feature_std.to(model.device), k = k).clone().cpu().detach().numpy()\n",
     "    \n",
@@ -838,7 +838,7 @@
     "    model = MarkerMap(input_size, hidden_layer_size, z_size, k = k, t = global_t, bias = True, temperature_decay=0.95, alpha = 0.95, batch_norm = batch_norm, loss_tradeoff = 1.0, num_classes = None)\n",
     "    tmp_path = model_save_path + 'marker_map_unsupervised_{}.ckpt'.format(tryy)\n",
     "    # DO NOT USE IN OTHER WORKLOADS\n",
-    "    train_save_model(model, train_dataloader, val_dataloader, tmp_path, gpus=1, min_epochs = 25, max_epochs = 100, auto_lr = True, max_lr = 0.0001, early_stopping_patience = 4, \n",
+    "    train_save_model(model, train_dataloader, val_dataloader, tmp_path, gpus=gpus, min_epochs = 25, max_epochs = 100, auto_lr = True, max_lr = 0.0001, early_stopping_patience = 4, \n",
     "                     lr_explore_mode = 'linear', num_lr_rates = 500, precision = precision)\n",
     "    unsupervised_markers = model.markers().clone().cpu().detach().numpy()\n",
     "    \n",
@@ -959,7 +959,7 @@
     "\n",
     "    model = ConcreteVAE_NMSL(input_size, hidden_layer_size, z_size, k = k, t = global_t, bias = True, temperature_decay = 0.95, batch_norm = batch_norm)\n",
     "    tmp_path = model_save_path + 'concrete_vae_{}.ckpt'.format(tryy)\n",
-    "    train_save_model(model, train_dataloader, val_dataloader, tmp_path, gpus=1, min_epochs = 50, max_epochs = 100, auto_lr = True, max_lr = 0.0001, early_stopping_patience = 10, \n",
+    "    train_save_model(model, train_dataloader, val_dataloader, tmp_path, gpus=gpus, min_epochs = 50, max_epochs = 100, auto_lr = True, max_lr = 0.0001, early_stopping_patience = 10, \n",
     "                     lr_explore_mode = 'linear', num_lr_rates = 500)\n",
     "    concrete_vae_markers = model.markers().clone().cpu().detach().numpy()\n",
     "    \n",
@@ -1585,7 +1585,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1599,7 +1599,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/Mouse_Brain_Broad.ipynb
+++ b/notebooks/Mouse_Brain_Broad.ipynb
@@ -111,7 +111,7 @@
     "k = 50\n",
     "num_times = 10\n",
     "\n",
-    "gpus = None\n",
+    "gpus = 1\n",
     "tpu_cores = None\n",
     "precision = 32\n",
     "\n",


### PR DESCRIPTION
## Changes
- have num_cores and gpus use the specified parameters in the mouse notebook
- moving to a doc strings to format comments: https://www.python.org/dev/peps/pep-0257/
- I think Docstrings can be used to automatically generate documentation, so this will be nice in the future
- add/update some comments to some of the split_into_dataloaders functions and the continuous relaxation functions borrowed from the package

## Tests
- ran through the Mouse notebook with the changes

## Doc Changes
- none
