### PR TITLE
benchmark smashpy, L1_VAE

### DIFF
--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -116,6 +116,10 @@ elif data_name == 'paul':
 elif data_name == 'cite_seq':
   adata, X, y, encoder = getCiteSeq('data/cite_seq/CITEseq.h5ad')
 
+# The smashpy methods set global seeds that mess with sampling. These seeds are used
+# to stop those methods from using the same global seed over and over.
+random_seeds_queue = SmashPyWrapper.getRandomSeedsQueue()
+
 input_size = X.shape[1]
 
 # Declare models
@@ -233,6 +237,36 @@ global_gate = VAE_Gumbel_GlobalGate.getBenchmarker(
   }
 )
 
+smash_rf = SmashPyWrapper.getBenchmarker(
+  create_kwargs = { 'adata': adata },
+  train_kwargs = { 'restrict_top': ('global', 25) },
+  model='RandomForest',
+  random_seeds_queue = random_seeds_queue,
+)
+
+smash_dnn = SmashPyWrapper.getBenchmarker(
+  create_kwargs = { 'adata': adata },
+  train_kwargs = { 'restrict_top': ('global', 25) },
+  model='DNN',
+  random_seeds_queue = random_seeds_queue,
+)
+
+l1_vae = VAE_l1_diag.getBenchmarker(
+  create_kwargs = {
+    'input_size': input_size,
+    'hidden_layer_size': hidden_layer_size,
+    'z_size': z_size,
+    'batch_norm': batch_norm,
+  },
+  train_kwargs = {
+    'gpus': gpus,
+    'min_epochs': 25,
+    'max_epochs': max_epochs,
+    'early_stopping_patience': 4,
+    'precision': precision,
+  },
+)
+
 misclass_rates, benchmark_label, benchmark_range = benchmark(
   {
     UNSUP_MM: unsupervised_mm,
@@ -242,6 +276,9 @@ misclass_rates, benchmark_label, benchmark_range = benchmark(
     LASSONET: LassoNetWrapper.getBenchmarker(),
     CONCRETE_VAE: concrete_vae,
     GLOBAL_GATE: global_gate,
+    SMASH_RF: smash_rf,
+    SMASH_DNN: smash_dnn,
+    L1_VAE: l1_vae,
   },
   num_times,
   X,

--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -118,7 +118,7 @@ elif data_name == 'cite_seq':
 
 # The smashpy methods set global seeds that mess with sampling. These seeds are used
 # to stop those methods from using the same global seed over and over.
-random_seeds_queue = SmashPyWrapper.getRandomSeedsQueue()
+random_seeds_queue = SmashPyWrapper.getRandomSeedsQueue(length = len(k_range) * num_times * 5)
 
 input_size = X.shape[1]
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -248,6 +248,14 @@ class BenchmarkableModel():
         return partial(cls.benchmarkerFunctional, create_kwargs, train_kwargs)
 
     def prepareData(X, y, train_indices, val_indices):
+        """
+        Sorts X and y data into train and val sets based on the provided indices
+        args:
+            X (np.array): input data, counts of various proteins
+            y (np.array): output data, what type of cell it is
+            train_indices (array-like): the indices to be used as the training set
+            val_indices (array-like): the indices to be used as the validation set
+        """
         X_train = X[train_indices, :]
         y_train = y[train_indices]
         X_val = X[val_indices, :]
@@ -620,6 +628,12 @@ class VAE_l1_diag(VAE):
             val_dataloader (pytorch dataloader): dataloader for validation data set
             k (int): k value for the model, the number of markers to select
         """
+        if not k:
+            k = train_kwargs['k']
+
+        if k in train_kwargs:
+            train_kwargs.pop('k')
+
         feature_std = torch.tensor(X).std(dim = 0)
         model = cls(**create_kwargs)
         train_model(model, train_dataloader, val_dataloader, **train_kwargs)


### PR DESCRIPTION
## Changes
- add the smashpy wrapper class, it has a lot of custom code to handle the issues with smashpy (printing, plotting, messing with np.random's seeds)
- add benchmarkerFunctional for L1_VAE
- for benchmarkerFunctional, swap to passing X,y, train_indices, and val_indices to allow each model to better control what data goes in. This is achieved in a model `prepareData` function

## Testing
- ran the benchmark script with the new model wrappers
- ran the benchmark script with a subset of the old model wrappers

## Doc Changes
- some updates to the comments