### PR TITLE
benchmark save

### DIFF
--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -284,6 +284,7 @@ misclass_rates, benchmark_label, benchmark_range = benchmark(
   X,
   y,
   benchmark='k',
+  save_path='checkpoints/',
   k_range=k_range,
 )
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1618,9 +1618,21 @@ def model_variances(path, tries):
     return np.mean(misclass_arr), np.mean(weight_f1_arr), np.std(misclass_arr), np.std(weight_f1_arr)
 
 
-def benchmark(models, num_times, X, y, benchmark, train_size = 0.7, val_size = 0.1, batch_size = 64, k_range=None):
+def benchmark(
+    models,
+    num_times,
+    X,
+    y,
+    benchmark,
+    train_size = 0.7,
+    val_size = 0.1,
+    batch_size = 64,
+    save_path=None,
+    k_range=None,
+):
     """
-    Benchmark a collection of models by a benchmark param on data X,y
+    Benchmark a collection of models by a benchmark param on data X,y. If save_path is specified, results are saved
+    when a complete benchmark_range is complete
     args:
         models (dict): maps model labels to a function that runs the model on the data and returns markers
             use model.getBenchmarker() to automatically generate those functions
@@ -1631,9 +1643,12 @@ def benchmark(models, num_times, X, y, benchmark, train_size = 0.7, val_size = 0
         train_size (float): 0 to 1, fraction of data for train set, defaults to 0.7
         val_size (float): 0 to 1, fraction of data for validation set, defaults to 0.1
         batch_size (int): defaults to 64
+        save_path (string): if not None, folder to save results to, defaults to None
         k_range (array): when benchmarking on k, this is what you range over, defaults to none
     returns:
         (dict): maps model labels to an np.array (num_times x benchmark_levels) of misclass rates
+        (string): benchmark
+        (array-like): benchmark_range
     """
     if benchmark != 'k':
         raise Exception('benchmark: Possible choices of benchmark are "k"')
@@ -1678,6 +1693,9 @@ def benchmark(models, num_times, X, y, benchmark, train_size = 0.7, val_size = 0
                     results[model_label] = k_range_results_ndarray
                 else:
                     results[model_label] = np.append(results[model_label], k_range_results_ndarray, axis=0)
+
+                if save_path:
+                    np.save(f'{save_path}benchmark_{benchmark}_{num_times}', results)
 
     if benchmark == 'k':
         return results, benchmark, k_range

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -61,3 +61,31 @@ class TestPlotBenchmarks:
       plot_benchmarks(misclass_rates, 'k', mode='accuracy', benchmark_range=[10,25])
       with pytest.raises(Exception):
         plot_benchmarks(misclass_rates, 'k', mode='fake_mode', benchmark_range=[10,25])
+
+  def test_mismatched_number_of_runs(self):
+    misclass_rates_1 = {
+      'Supervised Marker Map': np.array([
+        [0.08985025, 0.078203  , 0.19467554, 0.04159734],
+        [0.14475874, 0.23627288, 0.06322795, 0.05490849],
+        [0.14475874, 0.11148087, 0.08153078, 0.13311148],
+        [0.11480865, 0.09983361, 0.09816972, 0.05324459],
+        [0.1031614 , 0.08153078, 0.06489185, 0.04159734]]),
+      'Mixed Marker Map': np.array([
+        [0.45257903, 0.16139767, 0.1547421 , 0.11314476],
+        [0.34442596, 0.30116473, 0.16638935, 0.16472546],
+      ]),
+    }
+
+    misclass_rates_2 = {
+      'Supervised Marker Map': np.array([
+        [0.08985025, 0.078203  , 0.19467554, 0.04159734],
+      ]),
+      'Mixed Marker Map': np.array([
+        [0.45257903, 0.16139767, 0.1547421 , 0.11314476],
+        [0.34442596, 0.30116473, 0.16638935, 0.16472546],
+      ]),
+    }
+
+    with plt.ion():
+      plot_benchmarks(misclass_rates_1, 'k', benchmark_range=[10, 25, 50, 100])
+      plot_benchmarks(misclass_rates_2, 'k', benchmark_range=[10, 25, 50, 100])


### PR DESCRIPTION
## Changes
- stacked on the smashpy PR, will merge that one first
- add a param save_path that if specified, saves the results as each benchmark_range finishes so that if the script breaks part way through, some of the results are saved. This will also be useful when running on the MARCC cluster

## Tests
- unit tests
- loaded results from the .npy file and displayed them, have to use `np.load(file, allow_pickle=True).item()` since it saves a dict or np.arrays
- loaded results that had an uneven number of runs for different models, still worked fine

## Doc Changes
- none