### PR TITLE
benchmark noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 ## Features
 
 - The MarkerMap package provides functionality to easily benchmark different marker selection methods to evaluate performance under a number of metrics. Each model has a `getBenchmarker` function which takes model constructor parameters and trainer parameters and returns a model function. The `benchmark` function then takes all these model functions, a dataset, and the desired type of benchmarking and runs all the models to easily compare performance. See `scripts/benchmark_k` for examples.
+- Types of benchmarking:
+  - k: The number of markers to select from
+  - label_error: Given a range of percentages, pick that percent of points in the training + validation set and set their label to a random label form among the existing labels.
 
 ## Setup 
 

--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -99,10 +99,10 @@ batch_size = 64
 batch_norm = True
 
 global_t = 3.0
-k=50
+k=25
 
 k_range = [10, 25, 50, 100, 250]
-label_error_range = [0.05, 0.1, 0.2, 0.3, 0.5]
+label_error_range = [0.1, 0.2, 0.5, 0.75, 1]
 num_times = 1
 max_epochs = 100
 
@@ -271,16 +271,16 @@ l1_vae = VAE_l1_diag.getBenchmarker(
 
 misclass_rates, benchmark_label, benchmark_range = benchmark(
   {
-    # UNSUP_MM: unsupervised_mm,
-    # SUP_MM: supervised_mm,
-    # MIXED_MM: mixed_mm,
+    UNSUP_MM: unsupervised_mm,
+    SUP_MM: supervised_mm,
+    MIXED_MM: mixed_mm,
     BASELINE: RandomBaseline.getBenchmarker(train_kwargs = { 'k': k }),
-    # LASSONET: LassoNetWrapper.getBenchmarker(train_kwargs = { 'k': k }),
-    # CONCRETE_VAE: concrete_vae,
-    # GLOBAL_GATE: global_gate,
-    # SMASH_RF: smash_rf,
+    LASSONET: LassoNetWrapper.getBenchmarker(train_kwargs = { 'k': k }),
+    CONCRETE_VAE: concrete_vae,
+    GLOBAL_GATE: global_gate,
+    SMASH_RF: smash_rf,
     SMASH_DNN: smash_dnn,
-    # L1_VAE: l1_vae,
+    L1_VAE: l1_vae,
   },
   num_times,
   X,

--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -26,7 +26,7 @@ def getZeisel(file_path):
   encoder = LabelEncoder()
   encoder.fit(labels)
   y = encoder.transform(labels)
-  return adata, X, y, encoder
+  return X, y, encoder
 
 def getPaul(housekeeping_genes_dir):
   adata = sc.datasets.paul15()
@@ -69,7 +69,7 @@ def getPaul(housekeeping_genes_dir):
   encoder = LabelEncoder()
   encoder.fit(labels)
   y = encoder.transform(labels)
-  return adata, X, y, encoder
+  return X, y, encoder
 
 def getCiteSeq(file_path):
   adata = sc.read_h5ad(file_path)
@@ -79,7 +79,7 @@ def getCiteSeq(file_path):
   encoder = LabelEncoder()
   encoder.fit(labels)
   y = encoder.transform(labels)
-  return adata, X, y, encoder
+  return X, y, encoder
 
 
 # Main
@@ -111,11 +111,11 @@ gpus = None
 precision=32
 
 if data_name == 'zeisel':
-  adata, X, y, encoder = getZeisel('data/zeisel/Zeisel.h5ad')
+  X, y, encoder = getZeisel('data/zeisel/Zeisel.h5ad')
 elif data_name == 'paul':
-  adata, X, y, encoder = getPaul('data/paul15/')
+  X, y, encoder = getPaul('data/paul15/')
 elif data_name == 'cite_seq':
-  adata, X, y, encoder = getCiteSeq('data/cite_seq/CITEseq.h5ad')
+  X, y, encoder = getCiteSeq('data/cite_seq/CITEseq.h5ad')
 
 # The smashpy methods set global seeds that mess with sampling. These seeds are used
 # to stop those methods from using the same global seed over and over.
@@ -239,14 +239,12 @@ global_gate = VAE_Gumbel_GlobalGate.getBenchmarker(
 )
 
 smash_rf = SmashPyWrapper.getBenchmarker(
-  create_kwargs = { 'adata': adata },
   train_kwargs = { 'restrict_top': ('global', k) },
   model='RandomForest',
   random_seeds_queue = random_seeds_queue,
 )
 
 smash_dnn = SmashPyWrapper.getBenchmarker(
-  create_kwargs = { 'adata': adata },
   train_kwargs = { 'restrict_top': ('global', k) },
   model='DNN',
   random_seeds_queue = random_seeds_queue,

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,50 @@
+import sys
+import pytest
+import numpy as np
+
+sys.path.insert(1, './src/')
+from utils import mislabel_points
+
+class TestMislabelPoints:
+  y = np.array([1,1,2,1,0,3,4,5,1,2]) #length 10
+  eligible_indices = np.array([0,1,2,4,6,7])
+
+  def test_mislabel_percent(self):
+    with pytest.raises(AssertionError):
+      mislabel_points(self.y, -1, self.eligible_indices)
+
+    with pytest.raises(AssertionError) as e:
+      mislabel_points(self.y, 2, self.eligible_indices)
+
+    mislabel_points(self.y, 0.5, self.eligible_indices)
+
+  def test_eligible_indices(self):
+    bad_eligible_indices = np.array([0,1,2,3,4,5,6,7,8,9,10])
+
+    with pytest.raises(AssertionError):
+      mislabel_points(self.y, 0.5, bad_eligible_indices)
+
+    mislabel_points(self.y, 0.2)
+
+    #test that the unchanged indices are all the same in y and y_err
+    y_err = mislabel_points(self.y, 0.2, self.eligible_indices)
+    unchanged_indices = np.ones(len(self.y))
+    unchanged_indices[self.eligible_indices] = False
+    assert ((self.y == y_err)[unchanged_indices.astype(bool)]).all()
+
+  def test_mismatches_in_bounds(self):
+    y = np.random.randint(0, 10, 1000)
+    mislabel_percent = 0.2
+
+    y_err = mislabel_points(y, mislabel_percent)
+
+    assert len(y) == len(y_err)
+    mismatches = np.sum(y != y_err)
+    assert mismatches <= int(mislabel_percent * len(y))
+    assert mismatches > int(mislabel_percent * len(y) * 0.5) # technically possible, but v unlikely
+
+  def test_mislabels_from_y(self):
+    y_err = mislabel_points(self.y, 0.5)
+    unique_set = { x for x in np.unique(self.y) }
+    assert np.array([x in unique_set for x in y_err]).all()
+


### PR DESCRIPTION
## Changes
- add the ability to benchmark on label_error, you specify a range of percentages, and that percent of labels are randomized
- fixed the mislabeling process for smash, now it recreates adata from the input X and y from benchmark

## Tests
- unit tests
- ran a small sample of models locally, I am going to run a larger set on MARCC

## Doc Changes
- some small updates to the readme, but I need to add full examples later