### PR TITLE
disable checkpointing in train_model

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1403,7 +1403,7 @@ def train_model(model, train_dataloader, val_dataloader, gpus = None, tpu_cores 
     trainer = pl.Trainer(gpus = gpus, tpu_cores = tpu_cores, min_epochs = min_epochs, max_epochs = max_epochs, 
             auto_lr_find=auto_lr, callbacks=[early_stopping_callback], precision = precision, logger = verbose,
             # turn off some summaries
-            enable_model_summary=verbose, enable_progress_bar = verbose)
+            enable_model_summary=verbose, enable_progress_bar = verbose, enable_checkpointing=False)
     if auto_lr:
         # for some reason plural val_dataloaders
         lr_finder = trainer.tuner.lr_find(model, train_dataloaders = train_dataloader, val_dataloaders = val_dataloader, max_lr = max_lr, mode = lr_explore_mode, num_training = num_lr_rates)


### PR DESCRIPTION
## Changes
- teeny tiny PR that stops pytorch from automatically saving the epoch checkpoints, users can still use train_save_model to save the end result of the model as they will
- I had hoped it would provide some speed improvements since those files are dece large (~50mb), but it didn't seem to help much in the one test I ran

## Tests 
- ran a benchmark with the unsupervised marker map, epochs no longer get saved