### PR TITLE
save f1 benchmark as well, allow plotting of f1 in plot benchmarks

### DIFF
--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -406,7 +406,7 @@ l1_vae = VAE_l1_diag.getBenchmarker(
   },
 )
 
-misclass_rates, benchmark_label, benchmark_range = benchmark(
+results, benchmark_label, benchmark_range = benchmark(
   {
     UNSUP_MM: unsupervised_mm,
     SUP_MM: supervised_mm,
@@ -427,4 +427,4 @@ misclass_rates, benchmark_label, benchmark_range = benchmark(
   benchmark_range=k_range,
 )
 
-plot_benchmarks(misclass_rates, benchmark_label, benchmark_range, mode='accuracy', show_stdev=True)
+plot_benchmarks(results, benchmark_label, benchmark_range, mode='accuracy', show_stdev=True)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -7,11 +7,13 @@ from markermap.utils import plot_benchmarks
 class TestPlotBenchmarks:
   def test_one_model_3_tries(self):
     misclass_rates = {
-      'Unsupervised Marker Map': np.array([
-        [0.43427621, 0.16139767],
-        [0.40099834, 0.15141431],
-        [0.41930116, 0.34442596]
-      ]),
+      'misclass': {
+        'Unsupervised Marker Map': np.array([
+          [0.43427621, 0.16139767],
+          [0.40099834, 0.15141431],
+          [0.41930116, 0.34442596]
+        ]),
+      },
     }
 
     with plt.ion():
@@ -20,8 +22,10 @@ class TestPlotBenchmarks:
 
   def test_two_models_1_try(self):
     misclass_rates = {
-      'Supervised Marker Map': np.array([[0.18801997, 0.23460899]]),
-      'Mixed Marker Map': np.array([[0.19966722, 0.26622296]])
+      'misclass': {
+        'Supervised Marker Map': np.array([[0.18801997, 0.23460899]]),
+        'Mixed Marker Map': np.array([[0.19966722, 0.26622296]]),
+      },
     }
 
     with plt.ion():
@@ -30,19 +34,21 @@ class TestPlotBenchmarks:
 
   def test_two_models_5_tries(self):
     misclass_rates = {
-      'Supervised Marker Map': np.array([
-        [0.08985025, 0.078203  , 0.19467554, 0.04159734],
-        [0.14475874, 0.23627288, 0.06322795, 0.05490849],
-        [0.14475874, 0.11148087, 0.08153078, 0.13311148],
-        [0.11480865, 0.09983361, 0.09816972, 0.05324459],
-        [0.1031614 , 0.08153078, 0.06489185, 0.04159734]]),
-      'Mixed Marker Map': np.array([
-        [0.45257903, 0.16139767, 0.1547421 , 0.11314476],
-        [0.34442596, 0.30116473, 0.16638935, 0.16472546],
-        [0.52246256, 0.31780366, 0.15806988, 0.16638935],
-        [0.43926789, 0.15806988, 0.21464226, 0.06655574],
-        [0.44925125, 0.22462562, 0.22462562, 0.05990017]
-      ]),
+      'misclass': {
+        'Supervised Marker Map': np.array([
+          [0.08985025, 0.078203  , 0.19467554, 0.04159734],
+          [0.14475874, 0.23627288, 0.06322795, 0.05490849],
+          [0.14475874, 0.11148087, 0.08153078, 0.13311148],
+          [0.11480865, 0.09983361, 0.09816972, 0.05324459],
+          [0.1031614 , 0.08153078, 0.06489185, 0.04159734]]),
+        'Mixed Marker Map': np.array([
+          [0.45257903, 0.16139767, 0.1547421 , 0.11314476],
+          [0.34442596, 0.30116473, 0.16638935, 0.16472546],
+          [0.52246256, 0.31780366, 0.15806988, 0.16638935],
+          [0.43926789, 0.15806988, 0.21464226, 0.06655574],
+          [0.44925125, 0.22462562, 0.22462562, 0.05990017]
+        ]),
+      },
     }
 
     with plt.ion():
@@ -50,38 +56,49 @@ class TestPlotBenchmarks:
 
   def test_modes(self):
     misclass_rates = {
-      'Supervised Marker Map': np.array([[0.18801997, 0.23460899]]),
-      'Mixed Marker Map': np.array([[0.19966722, 0.26622296]])
+      'misclass': {
+        'Supervised Marker Map': np.array([[0.18801997, 0.23460899]]),
+        'Mixed Marker Map': np.array([[0.19966722, 0.26622296]]),
+      },
+      'f1': {
+        'Supervised Marker Map': np.array([[0.18801997, 0.23460899]]),
+        'Mixed Marker Map': np.array([[0.15, 0.201]]),
+      },
     }
 
     with plt.ion():
       plot_benchmarks(misclass_rates, 'k', mode='misclass', benchmark_range=[10,25])
       plot_benchmarks(misclass_rates, 'k', mode='accuracy', benchmark_range=[10,25])
+      plot_benchmarks(misclass_rates, 'k', mode='f1', benchmark_range=[10,25])
       with pytest.raises(Exception):
         plot_benchmarks(misclass_rates, 'k', mode='fake_mode', benchmark_range=[10,25])
 
   def test_mismatched_number_of_runs(self):
     misclass_rates_1 = {
-      'Supervised Marker Map': np.array([
-        [0.08985025, 0.078203  , 0.19467554, 0.04159734],
-        [0.14475874, 0.23627288, 0.06322795, 0.05490849],
-        [0.14475874, 0.11148087, 0.08153078, 0.13311148],
-        [0.11480865, 0.09983361, 0.09816972, 0.05324459],
-        [0.1031614 , 0.08153078, 0.06489185, 0.04159734]]),
-      'Mixed Marker Map': np.array([
-        [0.45257903, 0.16139767, 0.1547421 , 0.11314476],
-        [0.34442596, 0.30116473, 0.16638935, 0.16472546],
-      ]),
+      'misclass': {
+        'Supervised Marker Map': np.array([
+          [0.08985025, 0.078203  , 0.19467554, 0.04159734],
+          [0.14475874, 0.23627288, 0.06322795, 0.05490849],
+          [0.14475874, 0.11148087, 0.08153078, 0.13311148],
+          [0.11480865, 0.09983361, 0.09816972, 0.05324459],
+          [0.1031614 , 0.08153078, 0.06489185, 0.04159734]]),
+        'Mixed Marker Map': np.array([
+          [0.45257903, 0.16139767, 0.1547421 , 0.11314476],
+          [0.34442596, 0.30116473, 0.16638935, 0.16472546],
+        ]),
+      },
     }
 
     misclass_rates_2 = {
-      'Supervised Marker Map': np.array([
-        [0.08985025, 0.078203  , 0.19467554, 0.04159734],
-      ]),
-      'Mixed Marker Map': np.array([
-        [0.45257903, 0.16139767, 0.1547421 , 0.11314476],
-        [0.34442596, 0.30116473, 0.16638935, 0.16472546],
-      ]),
+      'misclass': {
+        'Supervised Marker Map': np.array([
+          [0.08985025, 0.078203  , 0.19467554, 0.04159734],
+        ]),
+        'Mixed Marker Map': np.array([
+          [0.45257903, 0.16139767, 0.1547421 , 0.11314476],
+          [0.34442596, 0.30116473, 0.16638935, 0.16472546],
+        ]),
+      },
     }
 
     with plt.ion():


### PR DESCRIPTION
## Changes
- review on ignore spacing changes for less changes in the test_plots file
- save f1 results in the benchmark function
- allow specifying 'f1' in the plot benchmarks function
- I saw how you did it with the model_variances function. I think saving all the results like that in separate and then using that function could be good, but it makes so many save files that transporting them back through ssh like I have been doing recently would be a pain. So I will keep consolidating it in 1 file like I am doing for now, I think.
- add to the unit tests

## Testing
- unit tests
- ran through a script, then printed the results for accuracy and f1

## Doc Changes
- none for the moment, just some comment updates