### PR TITLE
add benchmark quick start, update readme and add table of contents

### DIFF
--- a/notebooks/quick_start_benchmark.ipynb
+++ b/notebooks/quick_start_benchmark.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ed485152",
+   "metadata": {},
+   "source": [
+    "### Imports\n",
+    "Data is handled with numpy and with scanpy which is used for many computational biology datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b3a5ece",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import scanpy as sc\n",
+    "\n",
+    "from markermap.utils import RandomBaseline\n",
+    "from markermap.utils import MarkerMap\n",
+    "from markermap.utils import benchmark, parse_adata, plot_benchmarks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5385390f",
+   "metadata": {},
+   "source": [
+    "### Set Parameters\n",
+    "Define some parameters that we will use when creating the MarkerMap. \n",
+    "* z_size is the dimension of the latent space in the variational auto-encoder. We always use 16\n",
+    "* hidden_layer_size is the dimension of the hidden layers in the auto-encoder that come before and after the latent space layer. This is dependent on the data, a good rule of thumb is ~10% of the dimension of the input data. For the CITE-seq data which has 500 columns, we will use 64\n",
+    "* max_epochs is a value that we will pass during training to limit the number of epochs the models run\n",
+    "* Since we are benchmarking over a range of k values, we store them as k_range\n",
+    "* Set the file_path to wherever your data is"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fd8eb5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z_size = 16\n",
+    "hidden_layer_size = 64\n",
+    "max_epochs = 100\n",
+    "k_range = [10, 25, 50]\n",
+    "\n",
+    "\n",
+    "file_path = 'data/cite_seq/CITEseq.h5ad'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cff56390",
+   "metadata": {},
+   "source": [
+    "### Data\n",
+    "Set file_path to wherever your data is located. We then read in the data using scanpy and break it into X and y using the parse_data function. The text labels in adata.obs['annotation'] will be converted to number labels so that MarkerMap can use them properly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "435db789",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_path = '../data/cite_seq/CITEseq.h5ad'\n",
+    "\n",
+    "adata = sc.read_h5ad(file_path)\n",
+    "adata.obs['annotation'] = adata.obs['names']\n",
+    "X, y, encoder = parse_adata(adata)\n",
+    "X.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fee9ecb2",
+   "metadata": {},
+   "source": [
+    "### Define The Models\n",
+    "Now it is time to define all the models that we are benchmarking. For this tutorial, we will benchmark the three versions of MarkerMap: Supervised, Mixed, and Unsupervised. Each model in this repository comes with a function `getBenchmarker` where we specify all the parameters used for constructing the model and all the parameters used for training the model. The benchmark function will then run and evaluate them all. For this tutorial we will also specify a train argument, `max_epochs` which limits the number of epochs during training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "432338fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "supervised_marker_map = MarkerMap.getBenchmarker(\n",
+    "  create_kwargs = {\n",
+    "    'input_size': X.shape[1],\n",
+    "    'hidden_layer_size': hidden_layer_size,\n",
+    "    'z_size': z_size,\n",
+    "    'num_classes': len(np.unique(y)),\n",
+    "    'k': k_range[0], # because we are benchmarking over k, this will get replaced by the benchmark function\n",
+    "    'loss_tradeoff': 0,\n",
+    "  },\n",
+    "  train_kwargs = {\n",
+    "    'max_epochs': max_epochs,\n",
+    "  }\n",
+    ")\n",
+    "\n",
+    "mixed_marker_map = MarkerMap.getBenchmarker(\n",
+    "  create_kwargs = {\n",
+    "    'input_size': X.shape[1],\n",
+    "    'hidden_layer_size': hidden_layer_size,\n",
+    "    'z_size': z_size,\n",
+    "    'num_classes': len(np.unique(y)),\n",
+    "    'k': k_range[0],\n",
+    "    'loss_tradeoff': 0.5,\n",
+    "  },\n",
+    "  train_kwargs = {\n",
+    "    'max_epochs': max_epochs,\n",
+    "  }\n",
+    ")\n",
+    "\n",
+    "unsupervised_marker_map = MarkerMap.getBenchmarker(\n",
+    "  create_kwargs = {\n",
+    "    'input_size': X.shape[1],\n",
+    "    'hidden_layer_size': hidden_layer_size,\n",
+    "    'z_size': z_size,\n",
+    "    'num_classes': None, #since it is unsupervised, we can just say that the number of classes is None\n",
+    "    'k': k_range[0],\n",
+    "    'loss_tradeoff': 1.0,\n",
+    "  },\n",
+    "  train_kwargs = {\n",
+    "    'max_epochs': max_epochs,\n",
+    "  },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "643d2432",
+   "metadata": {},
+   "source": [
+    "### Run the Benchmark\n",
+    "Finally, we run the benchmark by passing in all the models as a dictionary, the number of times to run the model, the data and labels, the type of benchmark, and the range of values we are benchmarking over. Note that we also add the RandomBaseline model. This model selects k markers at random, and it is always a good idea to include this one because it performs better than might be expected. It is also very fast, so there is little downside.\n",
+    "\n",
+    "The benchmark function splits the data, runs each model with the specified k, then trains a simple model on just the k markers and evaluates how they perform on a test set that was not used to train the marker selection model or the simple evaluation model. The results reported have accuracy and f1 score, and we can visualize them in a plot with the plot_benchmarks function.\n",
+    "\n",
+    "This function will train each MarkerMap 3 times for a total of 9 runs, so it may take over 10 minutes depending on your hardware. Feel free to comment out some of the models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "519d2ff5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results, benchmark_label, benchmark_range = benchmark(\n",
+    "  {\n",
+    "    'Unsupervised Marker Map': unsupervised_marker_map,\n",
+    "    'Supervised Marker Map': supervised_marker_map,\n",
+    "    'Mixed Marker Map': mixed_marker_map,\n",
+    "    'Baseline': RandomBaseline.getBenchmarker(train_kwargs = { 'k': k_range[0] }),\n",
+    "  },\n",
+    "  1, # num_times, how many different random train/test splits to run the models on\n",
+    "  X,\n",
+    "  y,\n",
+    "  benchmark='k',\n",
+    "  benchmark_range=k_range,\n",
+    ")\n",
+    "\n",
+    "plot_benchmarks(results, benchmark_label, benchmark_range, mode='accuracy')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7c5d61b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/quick_start_benchmark.py
+++ b/scripts/quick_start_benchmark.py
@@ -1,0 +1,83 @@
+import numpy as np
+import scanpy as sc
+
+from markermap.utils import RandomBaseline
+from markermap.utils import MarkerMap
+from markermap.utils import benchmark, parse_adata, plot_benchmarks
+
+# Set parameters
+# z_size is the dimensionality of the latent space of the VAE
+z_size = 16
+# hidden_layer_size is the size of the hidden layers in the VAE before and after latent space
+hidden_layer_size = 64
+# the max_epochs for training the MarkerMaps
+max_epochs = 100
+
+file_path = 'data/cite_seq/CITEseq.h5ad'
+
+#get data
+adata = sc.read_h5ad(file_path)
+adata.obs['annotation'] = adata.obs['names']
+X, y, encoder = parse_adata(adata)
+
+# The range of k values to run the benchmark on
+k_range = [10, 25, 50]
+
+# Declare models
+unsupervised_marker_map = MarkerMap.getBenchmarker(
+  create_kwargs = {
+    'input_size': X.shape[1],
+    'hidden_layer_size': hidden_layer_size,
+    'z_size': z_size,
+    'num_classes': None,
+    'k': k,
+    'loss_tradeoff': 1.0,
+  },
+  train_kwargs = {
+    'max_epochs': max_epochs,
+  },
+)
+
+supervised_marker_map = MarkerMap.getBenchmarker(
+  create_kwargs = {
+    'input_size': X.shape[1],
+    'hidden_layer_size': hidden_layer_size,
+    'z_size': z_size,
+    'num_classes': len(np.unique(y)),
+    'k': k,
+    'loss_tradeoff': 0,
+  },
+  train_kwargs = {
+    'max_epochs': max_epochs,
+  }
+)
+
+mixed_marker_map = MarkerMap.getBenchmarker(
+  create_kwargs = {
+    'input_size': X.shape[1],
+    'hidden_layer_size': hidden_layer_size,
+    'z_size': z_size,
+    'num_classes': len(np.unique(y)),
+    'k': k,
+    'loss_tradeoff': 0.5,
+  },
+  train_kwargs = {
+    'max_epochs': max_epochs,
+  }
+)
+
+results, benchmark_label, benchmark_range = benchmark(
+  {
+    'Unsupervised Marker Map': unsupervised_marker_map,
+    'Supervised Marker Map': supervised_marker_map,
+    'Mixed Marker Map': mixed_marker_map,
+    'Baseline': RandomBaseline.getBenchmarker(train_kwargs = { 'k': k }),
+  },
+  1, # num_times, how many different random train/test splits to run the models on
+  X,
+  y,
+  benchmark='k',
+  benchmark_range=k_range,
+)
+
+plot_benchmarks(results, benchmark_label, benchmark_range, mode='accuracy')


### PR DESCRIPTION
## Changes
- again, it looks a little large because the same content is added 3 times
- add a benchmark_quick_start script for showing off the benchmarking features

## Testing
- test the notebook
- test the script
- visually inspect the readme, click on the links

## Doc Changes
- add the benchmark quick start section to the README
- add a table of contents to the README