### PR TITLE
fix param on supervised mm, add script to help me later print the results

### DIFF
--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -288,7 +288,7 @@ supervised_mm = MarkerMap.getBenchmarker(
     'min_epochs': 25,
     'max_epochs': max_epochs,
     'auto_lr': True,
-    'max_lr': 0.0001,
+    'max_lr': 0.001,
     'lr_explore_mode': 'linear',
     'num_lr_rates': 500,
     'precision': precision,

--- a/scripts/display_results.py
+++ b/scripts/display_results.py
@@ -1,0 +1,23 @@
+import sys
+import argparse
+import numpy as np
+
+from markermap.utils import plot_benchmarks
+
+def handleArgs(argv):
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-i', '--infile', help='the file to load results from', default=None)
+  parser.add_argument('-m', '--mode', help='the mode of plot_benchmarks', default='accuracy')
+
+  args = parser.parse_args()
+
+  return args.infile, args.mode
+
+#Main
+file, mode = handleArgs(sys.argv)
+
+results = np.load(file, allow_pickle=True).item()
+benchmark_label = 'k'
+benchmark_range = [10, 25, 50, 100, 250]
+
+plot_benchmarks(results, benchmark_label, benchmark_range, mode=mode, show_stdev=True, print_vals=True)

--- a/src/markermap/utils.py
+++ b/src/markermap/utils.py
@@ -2066,7 +2066,7 @@ def plot_confusion_matrix(cm,
     plt.show()
 
 
-def plot_benchmarks(results, benchmark_label, benchmark_range, mode='misclass', show_stdev=False):
+def plot_benchmarks(results, benchmark_label, benchmark_range, mode='misclass', show_stdev=False, print_vals=False):
     """
     Plot benchmark results of multiple models over the values that you are benchmarking on
     args:
@@ -2075,6 +2075,7 @@ def plot_benchmarks(results, benchmark_label, benchmark_range, mode='misclass', 
         benchmark_range (array): values that you are benchmarking over
         mode (string): one of {'misclass', 'accuracy', 'f1'}, defaults to 'misclass'
         show_stdev (bool): whether to show fill_between range of 1 stdev over the num_runs, defaults to false
+        print_vals (bool): print the vals that are displayed in the plot
     """
     mode_options = {'misclass', 'accuracy', 'f1'}
     if mode not in mode_options:
@@ -2105,6 +2106,9 @@ def plot_benchmarks(results, benchmark_label, benchmark_range, mode='misclass', 
         #plot the results for this model against the benchmarked range
         ax1.plot(benchmark_range, mean_result, label=label, marker=markers[i])
         i = (i+1) % len(markers)
+
+        if print_vals:
+            print(f'{label}: {mean_result}')
 
     ax1.set_title(f'{mode.capitalize()} Benchmark, over {num_runs} runs')
     ax1.set_xlabel(benchmark_label)


### PR DESCRIPTION
## Changes
- Just going to merge
- update the max_lr param for the supervised marker map from 0.0001 to 0.001. It turns out this was what was occasionally causing worse results for some of the data sets for the Supervised MM. I had miscopied this parameter from the notebooks.
- add a small script to make it easier to print the results as i get them

## Testing 
- ran the models, they now seem to be performing how they are in the notebooks
- run the script, printed some stuff