### PR TITLE
Gregory fix eval recon

### DIFF
--- a/scripts/evaluate_reconstruction.py
+++ b/scripts/evaluate_reconstruction.py
@@ -116,6 +116,10 @@ def trainAndGetReconMarkerMap(hidden_layer_size, z_size, k, train_dataloader, va
     unsupervised_marker_map,
     train_dataloader,
     val_dataloader,
+    min_epochs=25,
+    max_epochs=100,
+    max_lr=0.0001,
+    early_stopping_patience=4,
     gpus=gpus,
     lr_explore_mode='linear',
     num_lr_rates=500,
@@ -167,10 +171,8 @@ data_name, save_model, num_times, gpus, hidden_layer_size, k = handleArgs(sys.ar
 
 z_size = 16
 
-if data_name == 'zeisel':
-  _, y, encoder = get_zeisel('data/zeisel/Zeisel.h5ad')
-  X = np.load('../data/zeisel/zeisel_expression_counts.npy') #this is the set used by scVI, 3005 x 558, raw counts
-  scVI_X = X.copy()
+if data_name == 'zeisel': #don't have raw counts for scVI right now
+  X, y, encoder = get_zeisel('data/zeisel/Zeisel.h5ad')
 elif data_name == 'paul':
   X, y, encoder = get_paul(
     'data/paul15/house_keeping_genes_Mouse_bone_marrow.txt',
@@ -179,13 +181,13 @@ elif data_name == 'paul':
   )
   scVI_X = X.copy()
   X = log_and_normalize(X)
-elif data_name == 'cite_seq':
+elif data_name == 'cite_seq': #dont have raw counts for scVI right now
   X, y, encoder = get_citeseq('data/cite_seq/CITEseq.h5ad')
 elif data_name == 'mouse_brain':
   X, y, encoder = get_mouse_brain(
     'data/mouse_brain_broad/mouse_brain_all_cells_20200625.h5ad',
     'data/mouse_brain_broad/snRNA_annotation_astro_subtypes_refined59_20200823.csv',
-    log_transform=False, #scVI requires counts, so we will normalize and log transform after.
+    smashpy_preprocess=False, #scVI requires counts, so we will normalize and log transform after.
   )
 
   scVI_X = X.copy()

--- a/scripts/evaluate_reconstruction.py
+++ b/scripts/evaluate_reconstruction.py
@@ -116,11 +116,11 @@ def trainAndGetReconMarkerMap(hidden_layer_size, z_size, k, train_dataloader, va
     unsupervised_marker_map,
     train_dataloader,
     val_dataloader,
+    gpus=gpus,
     min_epochs=25,
     max_epochs=100,
     max_lr=0.0001,
     early_stopping_patience=4,
-    gpus=gpus,
     lr_explore_mode='linear',
     num_lr_rates=500,
   )

--- a/src/markermap/utils.py
+++ b/src/markermap/utils.py
@@ -2369,7 +2369,7 @@ def remove_features_pct_2groups(adata, group_by=None, pct1=0.9, pct2=0.5):
     adata = adata[:, adata.var["general"]]
     return adata
 
-def get_mouse_brain(mouse_brain_path, mouse_brain_labels_path, log_transform=True):
+def get_mouse_brain(mouse_brain_path, mouse_brain_labels_path, smashpy_preprocess=True):
     """
     Get the mouse brain data and remove outliers and perform normalization. Some of the decisions in this function are
     judgement calls, so users should inspect and make their own decisions.
@@ -2429,7 +2429,7 @@ def get_mouse_brain(mouse_brain_path, mouse_brain_labels_path, log_transform=Tru
     gc.collect()
     adata_snrna_raw = remove_features_pct_2groups(adata_snrna_raw, group_by="annotation", pct1=0.75, pct2=0.5)
 
-    if (log_transform):
+    if (smashpy_preprocess):
         sc.pp.normalize_per_cell(adata_snrna_raw, counts_per_cell_after=1e4)
         sc.pp.log1p(adata_snrna_raw)
         sc.pp.scale(adata_snrna_raw, max_value=10)


### PR DESCRIPTION
## Changes
- Fix for issue: https://github.com/Computational-Morphogenomics-Group/MarkerMap/issues/33
- For doing L2, it doesn't make sense to compare the average l2 distance of raw counts that we use in scVI, with the log transformed and normalized values that we use for MarkerMap. Thus we make sure to apply the same process for both data before comparing the L2
- In the process of fixing this, we discovered that the reconstruction evaluation metrics performed better when some of the preprocessing steps are not done. In particular, for when we normalized the counts across cells, and we mean center and unit variance the genes, metrics looking at the variances then get messed up. So instead, we only log 1+X transform the data, then mean center and unit variance across the entire X matrix, rather than by genes.

## Testing
- Ran the model for Paul and Mouse Brain, the two datasets that I have easy access to the raw counts before the variance normalizing.