### PR TITLE
fix plot_umap_embedding since old version visualize_save_embedding no longer exists

### DIFF
--- a/notebooks/CITE_seq.ipynb
+++ b/notebooks/CITE_seq.ipynb
@@ -51,16 +51,16 @@
     "from torch.autograd import Variable\n",
     "from torch.nn import functional as F\n",
     "\n",
-    "from markermap.utils import RankCorrWrapper\n",
+    "from markermap.utils import RankCorrWrapper, SmashPyWrapper\n",
     "from markermap.utils import MarkerMap, ConcreteVAE_NMSL, VAE_Gumbel_GlobalGate, VAE_l1_diag\n",
     "from markermap.utils import (\n",
     "    get_citeseq,\n",
     "    model_variances,\n",
     "    new_model_metrics, \n",
     "    plot_confusion_matrix,\n",
+    "    plot_umap_embedding, \n",
     "    split_data_into_dataloaders, \n",
     "    train_save_model,\n",
-    "    visualize_save_embedding, \n",
     ")"
    ]
   },
@@ -282,7 +282,7 @@
     "    np.save(model_save_path + 'all_markers_{}.npy'.format(tryy), all_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/all_markers_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'All Marker Visualization', path = viz_save_path + 'all_markers_{}.pdf'.format(tryy), markers = all_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'All Marker Visualization', path = viz_save_path + 'all_markers_{}.pdf'.format(tryy), markers = all_markers, close_fig = True)"
    ]
   },
   {
@@ -324,12 +324,12 @@
     "    np.random.seed(possible_seeds[seed_index])\n",
     "    seed_index += 1\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1)\n",
-    "    train_X_y = citeseq_adata[np.concatenate([train_indices, val_indices]), :]\n",
+    "    train_X_y = SmashPyWrapper.prepareData(X, y, train_indices, val_indices, 'annotation')\n",
     "    sm = smashpy.smashpy()\n",
     "    clf = sm.ensemble_learning(train_X_y, group_by=\"annotation\", classifier=\"RandomForest\", balance=True, verbose=True)\n",
     "    selectedGenes, selectedGenes_dict = sm.gini_importance(train_X_y, clf, group_by=\"annotation\", verbose=True, restrict_top=(\"global\", k))\n",
     "    # since this selects k per class, need select randomly from each classes\n",
-    "    smash_markers = citeseq_adata.var.index.get_indexer(selectedGenes)\n",
+    "    smash_markers = train_X_y.var.index.get_indexer(selectedGenes)\n",
     "\n",
     "    X_train = X[np.concatenate([train_indices, val_indices]), :]\n",
     "    y_train = y[np.concatenate([train_indices, val_indices])]\n",
@@ -340,7 +340,7 @@
     "    np.save(model_save_path + 'smash_rf_markers_k_{}.npy'.format(k), smash_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/smash_rf_indices_k_{}.npy'.format(k), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Smash Random Forest Marker Visualization', path = viz_save_path + 'smash_rf_markers_k_{}.png'.format(k), markers = smash_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Smash Random Forest Marker Visualization', path = viz_save_path + 'smash_rf_markers_k_{}.png'.format(k), markers = smash_markers, close_fig = True)"
    ]
   },
   {
@@ -357,12 +357,12 @@
     "    np.random.seed(possible_seeds[seed_index])\n",
     "    seed_index += 1\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1)\n",
-    "    train_X_y = citeseq_adata[np.concatenate([train_indices, val_indices]), :]\n",
+    "    train_X_y = SmashPyWrapper.prepareData(X, y, train_indices, val_indices, 'annotation')\n",
     "    sm = smashpy.smashpy()\n",
     "    clf = sm.ensemble_learning(train_X_y, group_by=\"annotation\", classifier=\"RandomForest\", balance=True, verbose=True)\n",
     "    selectedGenes, selectedGenes_dict = sm.gini_importance(train_X_y, clf, group_by=\"annotation\", verbose=True, restrict_top=(\"global\", k))\n",
     "    # since this selects k per class, need select randomly from each classes\n",
-    "    smash_markers = citeseq_adata.var.index.get_indexer(selectedGenes)\n",
+    "    smash_markers = train_X_y.var.index.get_indexer(selectedGenes)\n",
     "\n",
     "    X_train = X[np.concatenate([train_indices, val_indices]), :]\n",
     "    y_train = y[np.concatenate([train_indices, val_indices])]\n",
@@ -373,7 +373,7 @@
     "    np.save(model_save_path + 'smash_rf_markers_{}.npy'.format(tryy), smash_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/smash_rf_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Smash Random Forest Marker Visualization', path = viz_save_path + 'smash_rf_markers_{}.png'.format(tryy), markers = smash_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Smash Random Forest Marker Visualization', path = viz_save_path + 'smash_rf_markers_{}.png'.format(tryy), markers = smash_markers, close_fig = True)"
    ]
   },
   {
@@ -402,12 +402,12 @@
     "    np.random.seed(possible_seeds[seed_index])\n",
     "    seed_index += 1\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1)\n",
-    "    train_X_y = citeseq_adata[np.concatenate([train_indices, val_indices]), :]\n",
+    "    train_X_y = SmashPyWrapper.prepareData(X, y, train_indices, val_indices, 'annotation')\n",
     "    sm = smashpy.smashpy()\n",
-    "    sm.DNN(citeseq_adata, group_by=\"annotation\", model=None, balance=True, verbose=True, save=False)\n",
-    "    selectedGenes, selectedGenes_dict = sm.run_shap(citeseq_adata, group_by=\"annotation\", model=None, verbose=True, pct=0.1, restrict_top=(\"global\", k))\n",
+    "    sm.DNN(train_X_y, group_by=\"annotation\", model=None, balance=True, verbose=True, save=False)\n",
+    "    selectedGenes, selectedGenes_dict = sm.run_shap(train_X_y, group_by=\"annotation\", model=None, verbose=True, pct=0.1, restrict_top=(\"global\", k))\n",
     "    # since this selects k per class, need select randomly from each classes\n",
-    "    smash_markers = citeseq_adata.var.index.get_indexer(selectedGenes)\n",
+    "    smash_markers = train_X_y.var.index.get_indexer(selectedGenes)\n",
     "\n",
     "    X_train = X[np.concatenate([train_indices, val_indices]), :]\n",
     "    y_train = y[np.concatenate([train_indices, val_indices])]\n",
@@ -418,7 +418,7 @@
     "    np.save(model_save_path + 'smash_markers_k_{}.npy'.format(k), smash_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/smash_indices_k_{}.npy'.format(k), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Smash Marker Visualization', path = viz_save_path + 'smash_markers_k_{}.png'.format(k), markers = smash_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Smash Marker Visualization', path = viz_save_path + 'smash_markers_k_{}.png'.format(k), markers = smash_markers, close_fig = True)"
    ]
   },
   {
@@ -435,12 +435,12 @@
     "    np.random.seed(possible_seeds[seed_index])\n",
     "    seed_index += 1\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1)\n",
-    "    train_X_y = citeseq_adata[np.concatenate([train_indices, val_indices]), :]\n",
+    "    train_X_y = SmashPyWrapper.prepareData(X, y, train_indices, val_indices, 'annotation')\n",
     "    sm = smashpy.smashpy()\n",
     "    sm.DNN(train_X_y, group_by=\"annotation\", model=None, balance=True, verbose=True, save=False)\n",
     "    selectedGenes, selectedGenes_dict = sm.run_shap(train_X_y, group_by=\"annotation\", model=None, verbose=True, pct=0.1, restrict_top=(\"global\", k))\n",
     "    # since this selects k per class, need select randomly from each classes\n",
-    "    smash_markers = citeseq_adata.var.index.get_indexer(selectedGenes)\n",
+    "    smash_markers = train_X_y.var.index.get_indexer(selectedGenes)\n",
     "\n",
     "    X_train = X[np.concatenate([train_indices, val_indices]), :]\n",
     "    y_train = y[np.concatenate([train_indices, val_indices])]\n",
@@ -451,7 +451,7 @@
     "    np.save(model_save_path + 'smash_markers_{}.npy'.format(tryy), smash_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/smash_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Smash Marker Visualization', path = viz_save_path + 'smash_markers_{}.png'.format(tryy), markers = smash_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Smash Marker Visualization', path = viz_save_path + 'smash_markers_{}.png'.format(tryy), markers = smash_markers, close_fig = True)"
    ]
   },
   {
@@ -523,7 +523,7 @@
     "    np.save(model_save_path + 'rankcorr_markers_k_{}.npy'.format(k), rankcorr_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/rankcorr_indices_k_{}.npy'.format(k), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'RankCorr Marker Visualization', path = viz_save_path + 'rankcorr_markers_k_{}.png'.format(k), markers = rankcorr_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'RankCorr Marker Visualization', path = viz_save_path + 'rankcorr_markers_k_{}.png'.format(k), markers = rankcorr_markers, close_fig = True)"
    ]
   },
   {
@@ -557,7 +557,7 @@
     "    np.save(model_save_path + 'rankcorr_markers_{}.npy'.format(tryy), rankcorr_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/rankcorr_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'RankCorr Marker Visualization', path = viz_save_path + 'rankcorr_markers_{}.png'.format(tryy), markers = rankcorr_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'RankCorr Marker Visualization', path = viz_save_path + 'rankcorr_markers_{}.png'.format(tryy), markers = rankcorr_markers, close_fig = True)"
    ]
   },
   {
@@ -598,7 +598,7 @@
     "    np.save(model_save_path + 'l1_vae_markers_k_{}.npy'.format(k), l1_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/l1_vae_indices_k_{}.npy'.format(k), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'L1 VAE Marker Visualization', path = viz_save_path + 'l1_vae_markers_k_{}.png'.format(k), markers = l1_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'L1 VAE Marker Visualization', path = viz_save_path + 'l1_vae_markers_k_{}.png'.format(k), markers = l1_markers, close_fig = True)"
    ]
   },
   {
@@ -629,7 +629,7 @@
     "    np.save(model_save_path + 'l1_vae_markers_{}.npy'.format(tryy), l1_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/l1_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'L1 VAE Marker Visualization', path = viz_save_path + 'l1_vae_markers_{}.png'.format(tryy), markers = l1_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'L1 VAE Marker Visualization', path = viz_save_path + 'l1_vae_markers_{}.png'.format(tryy), markers = l1_markers, close_fig = True)"
    ]
   },
   {
@@ -670,7 +670,7 @@
     "    np.save(model_save_path + 'globalgate_vae_markers_k_{}.npy'.format(k), globalgate_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/globalgate_vae_indices_k_{}.npy'.format(k), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Global Gate VAE Marker Visualization', path = viz_save_path + 'globalgate_vae_markers_k_{}.png'.format(k), markers = globalgate_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Global Gate VAE Marker Visualization', path = viz_save_path + 'globalgate_vae_markers_k_{}.png'.format(k), markers = globalgate_markers, close_fig = True)"
    ]
   },
   {
@@ -701,7 +701,7 @@
     "    np.save(model_save_path + 'globalgate_vae_markers_{}.npy'.format(tryy), globalgate_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/globalgate_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Global Gate VAE Marker Visualization', path = viz_save_path + 'globalgate_vae_markers_{}.png'.format(tryy), markers = globalgate_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Global Gate VAE Marker Visualization', path = viz_save_path + 'globalgate_vae_markers_{}.png'.format(tryy), markers = globalgate_markers, close_fig = True)"
    ]
   },
   {
@@ -740,7 +740,7 @@
     "    np.save(model_save_path + 'marker_map_unsupervised_markers_k_{}.npy'.format(k), marker_map_unsupervised_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_unsupervised_indices_k_{}.npy'.format(k), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'MarkerMap Unsupervised Marker Visualization', path = viz_save_path + 'marker_map_unsupervised_markers_k_{}.png'.format(k), markers = marker_map_unsupervised_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'MarkerMap Unsupervised Marker Visualization', path = viz_save_path + 'marker_map_unsupervised_markers_k_{}.png'.format(k), markers = marker_map_unsupervised_markers, close_fig = True)"
    ]
   },
   {
@@ -769,7 +769,7 @@
     "    np.save(model_save_path + 'marker_map_unsupervised_markers_{}.npy'.format(tryy), unsupervised_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_unsupervised_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Marker Map Unsupervised Marker Visualization', path = viz_save_path + 'marker_map_unsupervised_markers_{}.png'.format(tryy), markers = unsupervised_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Marker Map Unsupervised Marker Visualization', path = viz_save_path + 'marker_map_unsupervised_markers_{}.png'.format(tryy), markers = unsupervised_markers, close_fig = True)"
    ]
   },
   {
@@ -810,7 +810,7 @@
     "    np.save(model_save_path + 'marker_map_supervised_markers_k_{}.npy'.format(k), markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_supervised_indices_k_{}.npy'.format(k), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'MarkerMap Supervised Marker Visualization', path = viz_save_path + 'marker_map_supervised_markers_k_{}.png'.format(k), markers = markers)"
+    "    plot_umap_embedding(X, y, encoder, 'MarkerMap Supervised Marker Visualization', path = viz_save_path + 'marker_map_supervised_markers_k_{}.png'.format(k), markers = markers, close_fig = True)"
    ]
   },
   {
@@ -841,7 +841,7 @@
     "    np.save(model_save_path + 'marker_map_supervised_markers_{}.npy'.format(tryy), markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_supervised_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'MarkerMap Supervised Marker Visualization', path = viz_save_path + 'marker_map_supervised_markers_{}.png'.format(tryy), markers = markers)"
+    "    plot_umap_embedding(X, y, encoder, 'MarkerMap Supervised Marker Visualization', path = viz_save_path + 'marker_map_supervised_markers_{}.png'.format(tryy), markers = markers, close_fig = True)"
    ]
   },
   {
@@ -882,7 +882,7 @@
     "    np.save(model_save_path + 'marker_map_mixed_markers_k_{}.npy'.format(tryy), markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_mixed_indices_k_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'MarkerMap Mixed Supervision Marker Visualization', path = viz_save_path + 'marker_map_mixed_markers_k_{}.png'.format(tryy), markers = markers)"
+    "    plot_umap_embedding(X, y, encoder, 'MarkerMap Mixed Supervision Marker Visualization', path = viz_save_path + 'marker_map_mixed_markers_k_{}.png'.format(tryy), markers = markers, close_fig = True)"
    ]
   },
   {
@@ -913,7 +913,7 @@
     "    np.save(model_save_path + 'marker_map_mixed_markers_{}.npy'.format(tryy), markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_mixed_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'MarkerMap Mixed Supervision Marker Visualization', path = viz_save_path + 'marker_map_mixed_markers_{}.png'.format(tryy), markers = markers)"
+    "    plot_umap_embedding(X, y, encoder, 'MarkerMap Mixed Supervision Marker Visualization', path = viz_save_path + 'marker_map_mixed_markers_{}.png'.format(tryy), markers = markers, close_fig = True)"
    ]
   },
   {
@@ -955,7 +955,7 @@
     "    np.save(model_save_path + 'concrete_vae_markers_k_{}.npy'.format(k), concrete_vae_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/concrete_vae_indices_k_{}.npy'.format(k), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Concrete VAE Marker Visualization', path = viz_save_path + 'concrete_vae_markers_k_{}.png'.format(k), markers = concrete_vae_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Concrete VAE Marker Visualization', path = viz_save_path + 'concrete_vae_markers_k_{}.png'.format(k), markers = concrete_vae_markers, close_fig = True)"
    ]
   },
   {
@@ -989,7 +989,7 @@
     "    np.save(model_save_path + 'concrete_vae_markers_{}.npy'.format(tryy), concrete_vae_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/concrete_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Concrete VAE Marker Visualization', path = viz_save_path + 'concrete_vae_markers_{}.png'.format(tryy), markers = concrete_vae_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Concrete VAE Marker Visualization', path = viz_save_path + 'concrete_vae_markers_{}.png'.format(tryy), markers = concrete_vae_markers, close_fig = True)"
    ]
   },
   {
@@ -1049,7 +1049,7 @@
     "    np.save(model_save_path + 'lasso_net_markers_{}.npy'.format(tryy), lasso_net_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/lasso_net_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'LassoNet Marker Visualization', path = viz_save_path + 'lasso_net_markers_{}.png'.format(tryy), markers = lasso_net_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'LassoNet Marker Visualization', path = viz_save_path + 'lasso_net_markers_{}.png'.format(tryy), markers = lasso_net_markers, close_fig = True)"
    ]
   },
   {
@@ -1075,7 +1075,7 @@
     "    np.save(model_save_path + 'lasso_net_results_k_{}.npy'.format(k), results)\n",
     "    np.save(model_save_path + 'lasso_net_markers_k_{}.npy'.format(k), lasso_net_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/lasso_net_indices_k_{}.npy'.format(k), (train_indices, val_indices, test_indices))\n",
-    "    visualize_save_embedding(X, y, encoder, 'LassoNet Marker Visualization', path = viz_save_path + 'lasso_net_markers_k_{}.png'.format(k), markers = lasso_net_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'LassoNet Marker Visualization', path = viz_save_path + 'lasso_net_markers_k_{}.png'.format(k), markers = lasso_net_markers, close_fig = True)"
    ]
   },
   {

--- a/notebooks/Mouse_Brain_Broad.ipynb
+++ b/notebooks/Mouse_Brain_Broad.ipynb
@@ -272,7 +272,6 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "num_times = 1\n",
     "for tryy in range(1,num_times+1):\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1, num_cores)\n",
     "    all_markers = np.arange(X.shape[1])\n",

--- a/notebooks/Mouse_Brain_Broad.ipynb
+++ b/notebooks/Mouse_Brain_Broad.ipynb
@@ -50,16 +50,16 @@
     "from torch.autograd import Variable\n",
     "from torch.nn import functional as F\n",
     "\n",
-    "from markermap.utils import RankCorrWrapper\n",
+    "from markermap.utils import RankCorrWrapper, SmashPyWrapper\n",
     "from markermap.utils import MarkerMap, ConcreteVAE_NMSL, VAE_Gumbel_GlobalGate, VAE_l1_diag\n",
     "from markermap.utils import (\n",
     "    get_mouse_brain,\n",
     "    model_variances,\n",
     "    new_model_metrics, \n",
     "    plot_confusion_matrix,\n",
+    "    plot_umap_embedding, \n",
     "    split_data_into_dataloaders, \n",
     "    train_save_model,\n",
-    "    visualize_save_embedding, \n",
     ")"
    ]
   },
@@ -272,6 +272,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
+    "num_times = 1\n",
     "for tryy in range(1,num_times+1):\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1, num_cores)\n",
     "    all_markers = np.arange(X.shape[1])\n",
@@ -284,7 +285,7 @@
     "    np.save(model_save_path + 'all_markers_{}.npy'.format(tryy), all_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/all_markers_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "    print('doing viz')\n",
-    "    #visualize_save_embedding(X, y, encoder, 'All Marker Visualization', path = viz_save_path + 'all_markers_{}.pdf'.format(tryy), markers = all_markers)\n"
+    "    #plot_umap_embedding(X, y, encoder, 'All Marker Visualization', path = viz_save_path + 'all_markers_{}.pdf'.format(tryy), markers = all_markers, close_fig = True)\n"
    ]
   },
   {
@@ -326,13 +327,13 @@
     "    np.random.seed(possible_seeds[seed_index])\n",
     "    seed_index += 1\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1, num_workers = num_cores)\n",
-    "    train_X_y = adata_snrna_raw[np.concatenate([train_indices, val_indices]), :]\n",
+    "    train_X_y = SmashPyWrapper.prepareData(X, y, train_indices, val_indices, 'annotation')\n",
     "    sm = smashpy.smashpy()\n",
     "    np.random.seed(np.random.randint(low=10, high = 1000))\n",
     "    clf = sm.ensemble_learning(train_X_y, group_by=\"annotation\", classifier=\"RandomForest\", balance=True, verbose=True)\n",
     "    selectedGenes, selectedGenes_dict = sm.gini_importance(train_X_y, clf, group_by=\"annotation\", verbose=True, restrict_top=(\"global\", k))\n",
     "    # since this selects k per class, need select randomly from each classes\n",
-    "    smash_markers = adata_snrna_raw.var.index.get_indexer(selectedGenes)\n",
+    "    smash_markers = train_X_y.var.index.get_indexer(selectedGenes)\n",
     "\n",
     "    X_train = X[np.concatenate([train_indices, val_indices]), :]\n",
     "    y_train = y[np.concatenate([train_indices, val_indices])]\n",
@@ -343,7 +344,7 @@
     "    np.save(model_save_path + 'smash_rf_markers_{}.npy'.format(tryy), smash_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/smash_rf_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    #visualize_save_embedding(X, y, encoder, 'Smash Random Forest Marker Visualization', path = viz_save_path + 'smash_rf_markers_{}.png'.format(tryy), markers = smash_markers)"
+    "    #plot_umap_embedding(X, y, encoder, 'Smash Random Forest Marker Visualization', path = viz_save_path + 'smash_rf_markers_{}.png'.format(tryy), markers = smash_markers, close_fig = True)"
    ]
   },
   {
@@ -372,12 +373,12 @@
     "    np.random.seed(possible_seeds[seed_index])\n",
     "    seed_index += 1\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1)\n",
-    "    train_X_y = adata_snrna_raw[np.concatenate([train_indices, val_indices]), :]\n",
+    "    train_X_y = SmashPyWrapper.prepareData(X, y, train_indices, val_indices, 'annotation')\n",
     "    sm = smashpy.smashpy()\n",
     "    sm.DNN(train_X_y, group_by=\"annotation\", model=None, balance=True, verbose=True, save=False)\n",
     "    selectedGenes, selectedGenes_dict = sm.run_shap(train_X_y, group_by=\"annotation\", model=None, verbose=True, pct=0.1, restrict_top=(\"global\", k))\n",
     "    # since this selects k per class, need select randomly from each classes\n",
-    "    smash_markers = adata_snrna_raw.var.index.get_indexer(selectedGenes)\n",
+    "    smash_markers = train_X_y.var.index.get_indexer(selectedGenes)\n",
     "\n",
     "    X_train = X[np.concatenate([train_indices, val_indices]), :]\n",
     "    y_train = y[np.concatenate([train_indices, val_indices])]\n",
@@ -388,7 +389,7 @@
     "    np.save(model_save_path + 'smash_markers_{}.npy'.format(tryy), smash_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/smash_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    #visualize_save_embedding(X, y, encoder, 'Smash Marker Visualization', path = viz_save_path + 'smash_markers_{}.png'.format(tryy), markers = smash_markers)"
+    "    #plot_umap_embedding(X, y, encoder, 'Smash Marker Visualization', path = viz_save_path + 'smash_markers_{}.png'.format(tryy), markers = smash_markers, close_fig = True)"
    ]
   },
   {
@@ -450,7 +451,7 @@
     "    np.save(model_save_path + 'rankcorr_markers_{}.npy'.format(tryy), rankcorr_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/rankcorr_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    #visualize_save_embedding(X, y, encoder, 'RankCorr Marker Visualization', path = viz_save_path + 'rankcorr_markers_{}.png'.format(tryy), markers = rankcorr_markers)"
+    "    #plot_umap_embedding(X, y, encoder, 'RankCorr Marker Visualization', path = viz_save_path + 'rankcorr_markers_{}.png'.format(tryy), markers = rankcorr_markers, close_fig = True)"
    ]
   },
   {
@@ -490,7 +491,7 @@
     "    np.save(model_save_path + 'l1_vae_markers_{}.npy'.format(tryy), l1_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/l1_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    #visualize_save_embedding(X, y, encoder, 'L1 VAE Marker Visualization', path = viz_save_path + 'l1_vae_markers_{}.png'.format(tryy), markers = l1_markers)"
+    "    #plot_umap_embedding(X, y, encoder, 'L1 VAE Marker Visualization', path = viz_save_path + 'l1_vae_markers_{}.png'.format(tryy), markers = l1_markers, close_fig = True)"
    ]
   },
   {
@@ -530,7 +531,7 @@
     "    np.save(model_save_path + 'globalgate_vae_markers_{}.npy'.format(tryy), globalgate_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/globalgate_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    #visualize_save_embedding(X, y, encoder, 'Global Gate VAE Marker Visualization', path = viz_save_path + 'globalgate_vae_markers_{}.png'.format(tryy), markers = globalgate_markers)"
+    "    #plot_umap_embedding(X, y, encoder, 'Global Gate VAE Marker Visualization', path = viz_save_path + 'globalgate_vae_markers_{}.png'.format(tryy), markers = globalgate_markers, close_fig = True)"
    ]
   },
   {
@@ -569,7 +570,7 @@
     "    np.save(model_save_path + 'marker_map_unsupervised_markers_{}.npy'.format(tryy), unsupervised_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_unsupervised_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    #visualize_save_embedding(X, y, encoder, 'Marker Map Unsupervised Marker Visualization', path = viz_save_path + 'marker_map_unsupervised_markers_{}.png'.format(tryy), markers = unsupervised_markers)"
+    "    #plot_umap_embedding(X, y, encoder, 'Marker Map Unsupervised Marker Visualization', path = viz_save_path + 'marker_map_unsupervised_markers_{}.png'.format(tryy), markers = unsupervised_markers, close_fig = True)"
    ]
   },
   {
@@ -610,7 +611,7 @@
     "    np.save(model_save_path + 'marker_map_supervised_markers_{}.npy'.format(tryy), markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_supervised_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    #visualize_save_embedding(X, y, encoder, 'MarkerMap Supervised Marker Visualization', path = viz_save_path + 'marker_map_supervised_markers_{}.png'.format(tryy), markers = markers)"
+    "    #plot_umap_embedding(X, y, encoder, 'MarkerMap Supervised Marker Visualization', path = viz_save_path + 'marker_map_supervised_markers_{}.png'.format(tryy), markers = markers, close_fig = True)"
    ]
   },
   {
@@ -651,7 +652,7 @@
     "    np.save(model_save_path + 'marker_map_mixed_markers_{}.npy'.format(tryy), markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_mixed_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    #visualize_save_embedding(X, y, encoder, 'MarkerMap Mixed Supervision Marker Visualization', path = viz_save_path + 'marker_map_mixed_markers_{}.png'.format(tryy), markers = markers)"
+    "    #plot_umap_embedding(X, y, encoder, 'MarkerMap Mixed Supervision Marker Visualization', path = viz_save_path + 'marker_map_mixed_markers_{}.png'.format(tryy), markers = markers, close_fig = True)"
    ]
   },
   {
@@ -690,7 +691,7 @@
     "    np.save(model_save_path + 'concrete_vae_markers_{}.npy'.format(tryy), concrete_vae_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/concrete_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    #visualize_save_embedding(X, y, encoder, 'Concrete VAE Marker Visualization', path = viz_save_path + 'concrete_vae_markers_{}.png'.format(tryy), markers = concrete_vae_markers)"
+    "    #plot_umap_embedding(X, y, encoder, 'Concrete VAE Marker Visualization', path = viz_save_path + 'concrete_vae_markers_{}.png'.format(tryy), markers = concrete_vae_markers, close_fig = True)"
    ]
   },
   {
@@ -738,7 +739,7 @@
     "    np.save(model_save_path + 'lasso_net_markers_{}.npy'.format(tryy), lasso_net_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/lasso_net_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    #visualize_save_embedding(X, y, encoder, 'LassoNet Marker Visualization', path = viz_save_path + 'lasso_net_markers_{}.png'.format(tryy), markers = lasso_net_markers)"
+    "    #plot_umap_embedding(X, y, encoder, 'LassoNet Marker Visualization', path = viz_save_path + 'lasso_net_markers_{}.png'.format(tryy), markers = lasso_net_markers, close_fig = True)"
    ]
   },
   {

--- a/notebooks/Paul.ipynb
+++ b/notebooks/Paul.ipynb
@@ -52,16 +52,16 @@
     "from torch.autograd import Variable\n",
     "from torch.nn import functional as F\n",
     "\n",
-    "from markermap.utils import RankCorrWrapper\n",
+    "from markermap.utils import RankCorrWrapper, SmashPyWrapper\n",
     "from markermap.utils import MarkerMap, ConcreteVAE_NMSL, VAE_Gumbel_GlobalGate, VAE_l1_diag\n",
     "from markermap.utils import (\n",
     "    get_paul,\n",
     "    model_variances,\n",
     "    new_model_metrics, \n",
     "    plot_confusion_matrix,\n",
+    "    plot_umap_embedding,\n",
     "    split_data_into_dataloaders, \n",
     "    train_save_model,\n",
-    "    visualize_save_embedding, \n",
     ")"
    ]
   },
@@ -284,7 +284,7 @@
     "    np.save(model_save_path + 'all_markers_{}.npy'.format(tryy), all_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/all_markers_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'All Marker Visualization', path = viz_save_path + 'all_markers_{}.pdf'.format(tryy), markers = all_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'All Marker Visualization', path = viz_save_path + 'all_markers_{}.pdf'.format(tryy), markers = all_markers, close_fig = True)"
    ]
   },
   {
@@ -326,12 +326,12 @@
     "    np.random.seed(possible_seeds[seed_index])\n",
     "    seed_index += 1\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1)\n",
-    "    train_X_y = adata[np.concatenate([train_indices, val_indices]), :]\n",
+    "    train_X_y = SmashPyWrapper.prepareData(X, y, train_indices, val_indices, 'annotation')\n",
     "    sm = smashpy.smashpy()\n",
     "    clf = sm.ensemble_learning(train_X_y, group_by=\"annotation\", classifier=\"RandomForest\", balance=True, verbose=True)\n",
     "    selectedGenes, selectedGenes_dict = sm.gini_importance(train_X_y, clf, group_by=\"annotation\", verbose=True, restrict_top=(\"global\", k))\n",
     "    # since this selects k per class, need select randomly from each classes\n",
-    "    smash_markers = adata.var.index.get_indexer(selectedGenes)\n",
+    "    smash_markers = train_X_y.var.index.get_indexer(selectedGenes)\n",
     "\n",
     "    X_train = X[np.concatenate([train_indices, val_indices]), :]\n",
     "    y_train = y[np.concatenate([train_indices, val_indices])]\n",
@@ -342,7 +342,7 @@
     "    np.save(model_save_path + 'smash_rf_markers_{}.npy'.format(tryy), smash_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/smash_rf_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Smash Random Forest Marker Visualization', path = viz_save_path + 'smash_rf_markers_{}.png'.format(tryy), markers = smash_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Smash Random Forest Marker Visualization', path = viz_save_path + 'smash_rf_markers_{}.png'.format(tryy), markers = smash_markers, close_fig = True)"
    ]
   },
   {
@@ -371,12 +371,12 @@
     "    np.random.seed(possible_seeds[seed_index])\n",
     "    seed_index += 1\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1)\n",
-    "    train_X_y = adata[np.concatenate([train_indices, val_indices]), :]\n",
+    "    train_X_y = SmashPyWrapper.prepareData(X, y, train_indices, val_indices, 'annotation')\n",
     "    sm = smashpy.smashpy()\n",
     "    sm.DNN(train_X_y, group_by=\"annotation\", model=None, balance=True, verbose=True, save=False)\n",
     "    selectedGenes, selectedGenes_dict = sm.run_shap(train_X_y, group_by=\"annotation\", model=None, verbose=True, pct=0.1, restrict_top=(\"global\", k))\n",
     "    # since this selects k per class, need select randomly from each classes\n",
-    "    smash_markers = adata.var.index.get_indexer(selectedGenes)\n",
+    "    smash_markers = train_X_y.var.index.get_indexer(selectedGenes)\n",
     "\n",
     "    X_train = X[np.concatenate([train_indices, val_indices]), :]\n",
     "    y_train = y[np.concatenate([train_indices, val_indices])]\n",
@@ -387,7 +387,7 @@
     "    np.save(model_save_path + 'smash_markers_{}.npy'.format(tryy), smash_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/smash_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Smash Marker Visualization', path = viz_save_path + 'smash_markers_{}.png'.format(tryy), markers = smash_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Smash Marker Visualization', path = viz_save_path + 'smash_markers_{}.png'.format(tryy), markers = smash_markers, close_fig = True)"
    ]
   },
   {
@@ -441,7 +441,7 @@
     "    np.save(model_save_path + 'rankcorr_markers_{}.npy'.format(tryy), rankcorr_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/rankcorr_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'RankCorr Marker Visualization', path = viz_save_path + 'rankcorr_markers_{}.png'.format(tryy), markers = rankcorr_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'RankCorr Marker Visualization', path = viz_save_path + 'rankcorr_markers_{}.png'.format(tryy), markers = rankcorr_markers, close_fig = True)"
    ]
   },
   {
@@ -482,7 +482,7 @@
     "    np.save(model_save_path + 'l1_vae_markers_{}.npy'.format(tryy), l1_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/l1_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'L1 VAE Marker Visualization', path = viz_save_path + 'l1_vae_markers_{}.png'.format(tryy), markers = l1_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'L1 VAE Marker Visualization', path = viz_save_path + 'l1_vae_markers_{}.png'.format(tryy), markers = l1_markers, close_fig = True)"
    ]
   },
   {
@@ -523,7 +523,7 @@
     "    np.save(model_save_path + 'globalgate_vae_markers_{}.npy'.format(tryy), globalgate_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/globalgate_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Global Gate VAE Marker Visualization', path = viz_save_path + 'globalgate_vae_markers_{}.png'.format(tryy), markers = globalgate_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Global Gate VAE Marker Visualization', path = viz_save_path + 'globalgate_vae_markers_{}.png'.format(tryy), markers = globalgate_markers, close_fig = True)"
    ]
   },
   {
@@ -562,7 +562,7 @@
     "    np.save(model_save_path + 'marker_map_unsupervised_markers_{}.npy'.format(tryy), unsupervised_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_unsupervised_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Marker Map Unsupervised Marker Visualization', path = viz_save_path + 'marker_map_unsupervised_markers_{}.png'.format(tryy), markers = unsupervised_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Marker Map Unsupervised Marker Visualization', path = viz_save_path + 'marker_map_unsupervised_markers_{}.png'.format(tryy), markers = unsupervised_markers, close_fig = True)"
    ]
   },
   {
@@ -603,7 +603,7 @@
     "    np.save(model_save_path + 'marker_map_supervised_markers_{}.npy'.format(tryy), markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_supervised_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'MarkerMap Supervised Marker Visualization', path = viz_save_path + 'marker_map_supervised_markers_{}.png'.format(tryy), markers = markers)"
+    "    plot_umap_embedding(X, y, encoder, 'MarkerMap Supervised Marker Visualization', path = viz_save_path + 'marker_map_supervised_markers_{}.png'.format(tryy), markers = markers, close_fig = True)"
    ]
   },
   {
@@ -2213,7 +2213,7 @@
     "    np.save(model_save_path + 'marker_map_mixed_markers_{}.npy'.format(tryy), markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_mixed_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'MarkerMap Mixed Supervision Marker Visualization', path = viz_save_path + 'marker_map_mixed_markers_{}.png'.format(tryy), markers = markers)"
+    "    plot_umap_embedding(X, y, encoder, 'MarkerMap Mixed Supervision Marker Visualization', path = viz_save_path + 'marker_map_mixed_markers_{}.png'.format(tryy), markers = markers, close_fig = True)"
    ]
   },
   {
@@ -2252,7 +2252,7 @@
     "    np.save(model_save_path + 'concrete_vae_markers_{}.npy'.format(tryy), concrete_vae_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/concrete_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Concrete VAE Marker Visualization', path = viz_save_path + 'concrete_vae_markers_{}.png'.format(tryy), markers = concrete_vae_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Concrete VAE Marker Visualization', path = viz_save_path + 'concrete_vae_markers_{}.png'.format(tryy), markers = concrete_vae_markers, close_fig = True)"
    ]
   },
   {
@@ -2305,7 +2305,7 @@
     "    np.save(model_save_path + 'lasso_net_markers_{}.npy'.format(tryy), lasso_net_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/lasso_net_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'LassoNet Marker Visualization', path = viz_save_path + 'lasso_net_markers_{}.png'.format(tryy), markers = lasso_net_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'LassoNet Marker Visualization', path = viz_save_path + 'lasso_net_markers_{}.png'.format(tryy), markers = lasso_net_markers, close_fig = True)"
    ]
   },
   {

--- a/notebooks/Zeisel.ipynb
+++ b/notebooks/Zeisel.ipynb
@@ -49,16 +49,16 @@
     "from torch.autograd import Variable\n",
     "from torch.nn import functional as F\n",
     "\n",
-    "from markermap.utils import RankCorrWrapper\n",
+    "from markermap.utils import RankCorrWrapper, SmashPyWrapper\n",
     "from markermap.utils import MarkerMap, ConcreteVAE_NMSL, VAE_Gumbel_GlobalGate, VAE_l1_diag\n",
     "from markermap.utils import (\n",
     "    get_zeisel,\n",
     "    model_variances,\n",
     "    new_model_metrics, \n",
     "    plot_confusion_matrix,\n",
+    "    plot_umap_embedding,\n",
     "    split_data_into_dataloaders, \n",
     "    train_save_model,\n",
-    "    visualize_save_embedding, \n",
     ")"
    ]
   },
@@ -312,7 +312,7 @@
     "    np.save(model_save_path + 'all_markers_{}.npy'.format(tryy), all_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/all_markers_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'All Marker Visualization', path = viz_save_path + 'all_markers_{}.pdf'.format(tryy), markers = all_markers)\n"
+    "    plot_umap_embedding(X, y, encoder, 'All Marker Visualization', path = viz_save_path + 'all_markers_{}.pdf'.format(tryy), markers = all_markers, close_fig = True)\n"
    ]
   },
   {
@@ -354,12 +354,12 @@
     "    np.random.seed(possible_seeds[seed_index])\n",
     "    seed_index += 1\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1)\n",
-    "    train_X_y = adata[np.concatenate([train_indices, val_indices]), :]\n",
+    "    train_X_y = SmashPyWrapper.prepareData(X, y, train_indices, val_indices, 'annotation')\n",
     "    sm = smashpy.smashpy()\n",
     "    clf = sm.ensemble_learning(train_X_y, group_by=\"annotation\", classifier=\"RandomForest\", balance=True, verbose=True)\n",
     "    selectedGenes, selectedGenes_dict = sm.gini_importance(train_X_y, clf, group_by=\"annotation\", verbose=True, restrict_top=(\"global\", k))\n",
     "    # since this selects k per class, need select randomly from each classes\n",
-    "    smash_markers = adata.var.index.get_indexer(selectedGenes)\n",
+    "    smash_markers = train_X_y.var.index.get_indexer(selectedGenes)\n",
     "\n",
     "    X_train = X[np.concatenate([train_indices, val_indices]), :]\n",
     "    y_train = y[np.concatenate([train_indices, val_indices])]\n",
@@ -370,7 +370,7 @@
     "    np.save(model_save_path + 'smash_rf_markers_{}.npy'.format(tryy), smash_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/smash_rf_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Smash Random Forest Marker Visualization', path = viz_save_path + 'smash_rf_markers_{}.png'.format(tryy), markers = smash_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Smash Random Forest Marker Visualization', path = viz_save_path + 'smash_rf_markers_{}.png'.format(tryy), markers = smash_markers, close_fig = True)"
    ]
   },
   {
@@ -399,12 +399,12 @@
     "    np.random.seed(possible_seeds[seed_index])\n",
     "    seed_index += 1\n",
     "    _, _, _, train_indices, val_indices, test_indices = split_data_into_dataloaders(X, y, 0.7, 0.1)\n",
-    "    train_X_y = adata[np.concatenate([train_indices, val_indices]), :]\n",
+    "    train_X_y = SmashPyWrapper.prepareData(X, y, train_indices, val_indices, 'annotation')\n",
     "    sm = smashpy.smashpy()\n",
     "    sm.DNN(train_X_y, group_by=\"annotation\", model=None, balance=True, verbose=True, save=False)\n",
     "    selectedGenes, selectedGenes_dict = sm.run_shap(train_X_y, group_by=\"annotation\", model=None, verbose=True, pct=0.1, restrict_top=(\"global\", k))\n",
     "    # since this selects k per class, need select randomly from each classes\n",
-    "    smash_markers = adata.var.index.get_indexer(selectedGenes)\n",
+    "    smash_markers = train_X_y.var.index.get_indexer(selectedGenes)\n",
     "\n",
     "    X_train = X[np.concatenate([train_indices, val_indices]), :]\n",
     "    y_train = y[np.concatenate([train_indices, val_indices])]\n",
@@ -415,7 +415,7 @@
     "    np.save(model_save_path + 'smash_markers_{}.npy'.format(tryy), smash_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/smash_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Smash Marker Visualization', path = viz_save_path + 'smash_markers_{}.png'.format(tryy), markers = smash_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Smash Marker Visualization', path = viz_save_path + 'smash_markers_{}.png'.format(tryy), markers = smash_markers, close_fig = True)"
    ]
   },
   {
@@ -469,7 +469,7 @@
     "    np.save(model_save_path + 'rankcorr_markers_{}.npy'.format(tryy), rankcorr_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/rankcorr_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'RankCorr Marker Visualization', path = viz_save_path + 'rankcorr_markers_{}.png'.format(tryy), markers = rankcorr_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'RankCorr Marker Visualization', path = viz_save_path + 'rankcorr_markers_{}.png'.format(tryy), markers = rankcorr_markers, close_fig = True)"
    ]
   },
   {
@@ -510,7 +510,7 @@
     "    np.save(model_save_path + 'l1_vae_markers_{}.npy'.format(tryy), l1_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/l1_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'L1 VAE Marker Visualization', path = viz_save_path + 'l1_vae_markers_{}.png'.format(tryy), markers = l1_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'L1 VAE Marker Visualization', path = viz_save_path + 'l1_vae_markers_{}.png'.format(tryy), markers = l1_markers, close_fig = True)"
    ]
   },
   {
@@ -551,7 +551,7 @@
     "    np.save(model_save_path + 'globalgate_vae_markers_{}.npy'.format(tryy), globalgate_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/globalgate_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Global Gate VAE Marker Visualization', path = viz_save_path + 'globalgate_vae_markers_{}.png'.format(tryy), markers = globalgate_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Global Gate VAE Marker Visualization', path = viz_save_path + 'globalgate_vae_markers_{}.png'.format(tryy), markers = globalgate_markers, close_fig = True)"
    ]
   },
   {
@@ -590,7 +590,7 @@
     "    np.save(model_save_path + 'marker_map_unsupervised_markers_{}.npy'.format(tryy), unsupervised_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_unsupervised_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Marker Map Unsupervised Marker Visualization', path = viz_save_path + 'marker_map_unsupervised_markers_{}.png'.format(tryy), markers = unsupervised_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Marker Map Unsupervised Marker Visualization', path = viz_save_path + 'marker_map_unsupervised_markers_{}.png'.format(tryy), markers = unsupervised_markers, close_fig = True)"
    ]
   },
   {
@@ -627,7 +627,7 @@
     "    np.save(model_save_path + 'marker_map_supervised_markers_{}.npy'.format(tryy), markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_supervised_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'MarkerMap Supervised Marker Visualization', path = viz_save_path + 'marker_map_supervised_markers_{}.png'.format(tryy), markers = markers)"
+    "    plot_umap_embedding(X, y, encoder, 'MarkerMap Supervised Marker Visualization', path = viz_save_path + 'marker_map_supervised_markers_{}.png'.format(tryy), markers = markers, close_fig = True)"
    ]
   },
   {
@@ -668,7 +668,7 @@
     "    np.save(model_save_path + 'marker_map_mixed_markers_{}.npy'.format(tryy), markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/marker_map_mixed_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'MarkerMap Mixed Supervision Marker Visualization', path = viz_save_path + 'marker_map_mixed_markers_{}.png'.format(tryy), markers = markers)"
+    "    plot_umap_embedding(X, y, encoder, 'MarkerMap Mixed Supervision Marker Visualization', path = viz_save_path + 'marker_map_mixed_markers_{}.png'.format(tryy), markers = markers, close_fig = True)"
    ]
   },
   {
@@ -707,7 +707,7 @@
     "    np.save(model_save_path + 'concrete_vae_markers_{}.npy'.format(tryy), concrete_vae_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/concrete_vae_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'Concrete VAE Marker Visualization', path = viz_save_path + 'concrete_vae_markers_{}.png'.format(tryy), markers = concrete_vae_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'Concrete VAE Marker Visualization', path = viz_save_path + 'concrete_vae_markers_{}.png'.format(tryy), markers = concrete_vae_markers, close_fig = True)"
    ]
   },
   {
@@ -767,7 +767,7 @@
     "    np.save(model_save_path + 'lasso_net_markers_{}.npy'.format(tryy), lasso_net_markers)\n",
     "    np.save(model_save_path + 'experiment_data_folds/lasso_net_indices_{}.npy'.format(tryy), (train_indices, val_indices, test_indices))\n",
     "\n",
-    "    visualize_save_embedding(X, y, encoder, 'LassoNet Marker Visualization', path = viz_save_path + 'lasso_net_markers_{}.png'.format(tryy), markers = lasso_net_markers)"
+    "    plot_umap_embedding(X, y, encoder, 'LassoNet Marker Visualization', path = viz_save_path + 'lasso_net_markers_{}.png'.format(tryy), markers = lasso_net_markers, close_fig = True)"
    ]
   },
   {

--- a/src/markermap/utils.py
+++ b/src/markermap/utils.py
@@ -1986,9 +1986,9 @@ def benchmark(
 
 ### graph
 
-def plot_umap_embedding(X, y, encoder, title, path = None, markers = None, **umap_kwargs):
+def plot_umap_embedding(X, y, encoder, title, path = None, markers = None, close_fig = False, **umap_kwargs):
     """
-    Plot the umap embedding of the data, color and label based on y
+    Plot the umap embedding of the data, color and label based on y. Call matplotlib.pylot.show() after to display plot.
     args:
         X (np.array): The data that we are finding an embedding for, (n,d)
         y (np.array): The labels of the data, (n,)
@@ -1996,6 +1996,7 @@ def plot_umap_embedding(X, y, encoder, title, path = None, markers = None, **uma
         title (str): Title of the plot
         path (str): If provided, save the figure as the file path, defaults to None
         markers (np.array): indices of the markers, reduce X to only those markers
+        close_fig (bool): Whether the figure should be closed, useful in Jupyter Notebooks, defaults to False
         umap_kwargs (dict): dictionary of arguments you would pass to umap, like n_neighbors and min_dist. If those
             values are not passed, they will default to 10 and 0.05 respectively.
     """
@@ -2024,6 +2025,9 @@ def plot_umap_embedding(X, y, encoder, title, path = None, markers = None, **uma
     ax.legend()
     if path is not None:
         plt.savefig(path)
+
+    if close_fig:
+        plt.close(fig)
 
 
 def plot_confusion_matrix(cm,


### PR DESCRIPTION
## Changes
- Updated the Jupyter notebooks since I removed the `visualize_save_embedding` function and replaced with `plot_umap_embedding`, but I didn't update the jupyter notebooks last time
- add  the ability to close the figure in plot_umap_embedding, its better for the notebooks where we just want to save them
- fixed an issue with SmashPy code in the notebooks where we no longer have the adata kicking around, so we remake it from `SmashPyWrapper.prepareData`

## Testing
- Ran some of the notebooks

## Doc Changes
- None