### PR TITLE
add zeisel and mouse_brain lots of cell types

### DIFF
--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -27,7 +27,7 @@ SCANPY = 'Scanpy Rank Genes'
 COSG = 'COSG'
 
 def handleArgs(argv):
-  data_name_options = ['zeisel', 'paul', 'cite_seq', 'mouse_brain']
+  data_name_options = ['zeisel', 'zeisel_big', 'paul', 'cite_seq', 'mouse_brain', 'mouse_brain_big']
   eval_model_options = ['random_forest', 'k_nearest_neighbors']
   benchmark_options = ['k', 'label_error', 'label_error_markers_only']
 
@@ -87,6 +87,8 @@ precision=32
 
 if data_name == 'zeisel':
   X, y, encoder = get_zeisel(data_dir + 'zeisel/Zeisel.h5ad')
+elif data_name == 'zeisel_big':
+  X, y, encoder = get_zeisel(data_dir + 'zeisel/Zeisel.h5ad', 'names1')
 elif data_name == 'paul':
   X, y, encoder = get_paul(
     data_dir + 'paul15/house_keeping_genes_Mouse_bone_marrow.txt',
@@ -98,6 +100,12 @@ elif data_name == 'mouse_brain':
   X, y, encoder = get_mouse_brain(
     data_dir + 'mouse_brain_broad/mouse_brain_all_cells_20200625.h5ad',
     data_dir + 'mouse_brain_broad/snRNA_annotation_astro_subtypes_refined59_20200823.csv',
+  )
+elif data_name =='mouse_brain_big':
+  X, y, encoder = get_mouse_brain(
+    data_dir + 'mouse_brain_broad/mouse_brain_all_cells_20200625.h5ad',
+    data_dir + 'mouse_brain_broad/snRNA_annotation_astro_subtypes_refined59_20200823.csv',
+    relabel=False,
   )
 
 num_classes = len(np.unique(y))
@@ -266,10 +274,10 @@ results, benchmark_mode, benchmark_range = benchmark(
     # L1_VAE: l1_vae,
     RANK_CORR: RankCorrWrapper.getBenchmarker(train_kwargs = { 'k': k, 'lamb': 20 }),
     SCANPY: ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes }),
-    # SCANPY + ' overestim_var': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 't-test_overestim_var' }),
-    # SCANPY + ' wilcoxon': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon' }),
-    # SCANPY + ' wilcoxon tie': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon', 'tie_correct': True }),
-    # SCANPY + ' logreg': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'logreg' }),
+    SCANPY + ' overestim_var': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 't-test_overestim_var' }),
+    SCANPY + ' wilcoxon': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon' }),
+    SCANPY + ' wilcoxon tie': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon', 'tie_correct': True }),
+    SCANPY + ' logreg': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'logreg' }),
     COSG: COSGWrapper.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes }),
   },
   num_times,
@@ -279,6 +287,7 @@ results, benchmark_mode, benchmark_range = benchmark(
   benchmark=benchmark_mode,
   benchmark_range=benchmark_range,
   eval_model=eval_model,
+  min_groups=[2,0,1],
 )
 
 plot_benchmarks(results, benchmark_mode, benchmark_range, mode='accuracy', show_stdev=True, print_vals=True)

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -1,15 +1,14 @@
 import pytest
 import numpy as np
 
-from markermap.utils import split_data_into_dataloaders
-
-X = np.array([1,2,3,4,5,6,7,8]).reshape((4,2))
-y = np.array([0,1,0,1])
-
+from markermap.utils import split_data_into_dataloaders, split_data
 
 class TestDataloaders:
 
   def test_assertions_split_data_into_dataloaders(self):
+    X = np.array([1,2,3,4,5,6,7,8]).reshape((4,2))
+    y = np.array([0,1,0,1])
+
     #total split must be less than 1
     with pytest.raises(AssertionError):
       split_data_into_dataloaders(X,y,0.7,0.4)
@@ -20,3 +19,68 @@ class TestDataloaders:
 
     #pass all assertions
     split_data_into_dataloaders(X,y,0.7,0.1)
+
+  def test_split_data(self):
+    X = np.array([1,2,3,4,5,6,7,8]).reshape((4,2))
+    y = np.array([0,1,0,1])
+
+    # total split must be less than 1
+    with pytest.raises(AssertionError): 
+      split_data(X, y, [0.7, 0.4])
+
+    # X and y must be the same length
+    with pytest.raises(AssertionError):
+      split_data(X, y[:1], [0.7, 0.1, 0.2])
+
+    # min_groups must be same length as size_percents
+    with pytest.raises(AssertionError):
+      split_data(X, y, [0.7, 0.1, 0.2], min_groups=[0,0])
+
+    # check that sizes match for even splits
+    X = np.arange(20).reshape((10,2))
+    y = np.concatenate([np.ones(5), np.zeros(5)])
+    _, (train_indices, test_indices) = split_data(X, y, [0.7, 0.3])
+    assert len(train_indices) == 7
+    assert len(test_indices) == 3
+
+    # check that sizes match for uneven splits
+    X = np.arange(20).reshape((10,2))
+    y = np.concatenate([np.ones(5), np.zeros(5)])
+    _, (train_indices, test_indices) = split_data(X, y, [0.65, 0.35])
+    assert len(train_indices) == 6
+    assert len(test_indices) == 4
+
+    # check that sizes match for uneven splits
+    X = np.arange(20).reshape((10,2))
+    y = np.concatenate([np.ones(5), np.zeros(5)])
+    _, (train_indices, test_indices) = split_data(X, y, [0.65, 0.35])
+    assert len(train_indices) == 6
+    assert len(test_indices) == 4
+
+  def test_split_data_min_groups(self):
+    # check that sizes match when using min groups
+    X = np.arange(20).reshape((10,2))
+    y = np.concatenate([np.ones(5), np.zeros(5)])
+    _, (train_indices, test_indices) = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
+    assert np.sum(y[train_indices] == 0) > 1 and np.sum(y[train_indices] == 1) > 1
+
+    # check that min_groups don't make a set too large
+    X = np.arange(20).reshape((10,2))
+    y = np.arange(10)
+    with pytest.raises(AssertionError):
+      _, (train_indices, test_indices) = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
+
+    # check that min_group is achievable
+    X = np.arange(20).reshape((10,2))
+    y = np.concatenate([np.ones(1), np.zeros(9)])
+    with pytest.raises(AssertionError):
+      _, (train_indices, test_indices) = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
+
+    # Check that min_groups is calculated first to ensure that they are all satisfied
+    X = np.arange(20).reshape((10,2))
+    y = np.concatenate([np.ones(2), np.zeros(8)])
+    _, (train_indices, test_indices) = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
+    assert np.sum(y[train_indices] == 0) == 6
+    assert np.sum(y[train_indices] == 1) == 1
+    assert np.sum(y[test_indices] == 0) == 2
+    assert np.sum(y[test_indices] == 1) == 1


### PR DESCRIPTION
## Changes
- add the ability for zeisel and mouse_brain to use the many cell types classification, rather than just the broad groups
- with more cell types, some of the methods struggle when a single cell type only has 1 representative of that group. Therefore, I wrote a new `split_data` function where you can specify the minimum number of representatives per group in each set (train, val, test).
- the `ensemble_learning` function of smashpy resampled the groups, so I copied the code over so it couldn't do that.

## Testing
- added unit tests for new split_data
- ran benchmark script with the zeisel_big and mouse_brain_big

## Doc Changes
- none
