### PR TITLE
Gregory persist2

### DIFF
--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -54,6 +54,7 @@ def handleArgs(argv):
     default='classify',
   )
   parser.add_argument('--single_val', help='use when you don\'t want to benchmark on a range', type=int, default=None)
+  parser.add_argument('--seed', help='random seed', default=None, type=int)
 
   args = parser.parse_args()
 
@@ -68,6 +69,7 @@ def handleArgs(argv):
     args.data_dir,
     args.eval_type,
     args.single_val,
+    args.seed,
   )
 
 # Main
@@ -82,6 +84,7 @@ def handleArgs(argv):
   data_dir,
   eval_type,
   single_val,
+  seed,
 ) = handleArgs(sys.argv)
 
 if eval_model is None:
@@ -140,6 +143,10 @@ elif data_name =='mouse_brain_big':
 
 num_classes = len(adata.obs['annotation'].unique())
 
+if seed is not None:
+  np.random.seed(seed)
+else:
+  print('WARNING! If you don\'t set a seed, smashpy will set your seed to 42 ON PACKAGE IMPORT.')
 # The smashpy methods set global seeds that mess with sampling. These seeds are used
 # to stop those methods from using the same global seed over and over.
 random_seeds_queue = SmashPyWrapper.getRandomSeedsQueue(length = len(benchmark_range) * num_times * 5)

--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -24,7 +24,8 @@ LASSONET = 'LassoNet'
 RANK_CORR = 'RankCorr'
 SCANPY = 'Scanpy Rank Genes'
 COSG = 'COSG'
-PERSIST = 'PERSIST'
+UNSUP_PERSIST = 'Unsupervised PERSIST'
+SUP_PERSIST = 'Supervised PERSIST'
 
 def handleArgs(argv):
   data_name_options = ['zeisel', 'zeisel_big', 'paul', 'cite_seq', 'mouse_brain', 'mouse_brain_big']
@@ -291,24 +292,25 @@ l1_vae = VAE_l1_diag.getBenchmarker(
 
 results, benchmark_mode, benchmark_range = benchmark(
   {
-    # UNSUP_MM: unsupervised_mm,
-    # SUP_MM: supervised_mm,
-    # MIXED_MM: mixed_mm,
-    # BASELINE: RandomBaseline.getBenchmarker(train_kwargs = { 'k': k }),
-    # LASSONET: LassoNetWrapper.getBenchmarker(train_kwargs = { 'k': k }),
-    # CONCRETE_VAE: concrete_vae,
-    # GLOBAL_GATE: global_gate,
-    # SMASH_RF: smash_rf,
-    # # SMASH_DNN: smash_dnn,
-    # # L1_VAE: l1_vae,
-    # RANK_CORR: RankCorrWrapper.getBenchmarker(train_kwargs = { 'k': k, 'lamb': 20 }),
-    # SCANPY: ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes }),
-    # SCANPY + ' overestim_var': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 't-test_overestim_var' }),
-    # SCANPY + ' wilcoxon': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon' }),
-    # SCANPY + ' wilcoxon tie': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon', 'tie_correct': True }),
-    # # SCANPY + ' logreg': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'logreg' }),
-    # COSG: COSGWrapper.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes }),
-    PERSIST: PersistWrapper.getBenchmarker(train_kwargs = { 'k': k }),
+    UNSUP_MM: unsupervised_mm,
+    SUP_MM: supervised_mm,
+    MIXED_MM: mixed_mm,
+    BASELINE: RandomBaseline.getBenchmarker(train_kwargs = { 'k': k }),
+    LASSONET: LassoNetWrapper.getBenchmarker(train_kwargs = { 'k': k }),
+    CONCRETE_VAE: concrete_vae,
+    GLOBAL_GATE: global_gate,
+    SMASH_RF: smash_rf,
+    # SMASH_DNN: smash_dnn,
+    # L1_VAE: l1_vae,
+    RANK_CORR: RankCorrWrapper.getBenchmarker(train_kwargs = { 'k': k, 'lamb': 20 }),
+    SCANPY: ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes }),
+    SCANPY + ' overestim_var': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 't-test_overestim_var' }),
+    SCANPY + ' wilcoxon': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon' }),
+    SCANPY + ' wilcoxon tie': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon', 'tie_correct': True }),
+    # SCANPY + ' logreg': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'logreg' }),
+    COSG: COSGWrapper.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes }),
+    SUP_PERSIST: PersistWrapper.getBenchmarker(create_kwargs = { 'supervised': True }, train_kwargs = { 'k': k }),
+    UNSUP_PERSIST: PersistWrapper.getBenchmarker(create_kwargs = { 'supervised': False }, train_kwargs = { 'k': k }),
   },
   num_times,
   adata,

--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -6,7 +6,7 @@ from sklearn.neighbors import KNeighborsClassifier
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LinearRegression
 
-from markermap.other_models import SmashPyWrapper, LassoNetWrapper, RandomBaseline, RankCorrWrapper, ScanpyRankGenes, COSGWrapper
+from markermap.other_models import SmashPyWrapper, LassoNetWrapper, RandomBaseline, RankCorrWrapper, ScanpyRankGenes, COSGWrapper, PersistWrapper
 from markermap.vae_models import MarkerMap, ConcreteVAE_NMSL, VAE_Gumbel_GlobalGate, VAE_l1_diag
 from markermap.utils import benchmark, plot_benchmarks, get_citeseq, get_mouse_brain, get_paul, get_zeisel
 
@@ -24,6 +24,7 @@ LASSONET = 'LassoNet'
 RANK_CORR = 'RankCorr'
 SCANPY = 'Scanpy Rank Genes'
 COSG = 'COSG'
+PERSIST = 'PERSIST'
 
 def handleArgs(argv):
   data_name_options = ['zeisel', 'zeisel_big', 'paul', 'cite_seq', 'mouse_brain', 'mouse_brain_big']
@@ -114,35 +115,35 @@ max_epochs = 100
 precision=32
 
 if data_name == 'zeisel':
-  X, y, encoder = get_zeisel(data_dir + 'zeisel/Zeisel.h5ad')
+  adata = get_zeisel(data_dir + 'zeisel/Zeisel.h5ad')
 elif data_name == 'zeisel_big':
-  X, y, encoder = get_zeisel(data_dir + 'zeisel/Zeisel.h5ad', 'names1')
+  adata = get_zeisel(data_dir + 'zeisel/Zeisel.h5ad', 'names1')
 elif data_name == 'paul':
-  X, y, encoder = get_paul(
+  adata = get_paul(
     data_dir + 'paul15/house_keeping_genes_Mouse_bone_marrow.txt',
     data_dir + 'paul15/house_keeping_genes_Mouse_HSC.txt',
   )
 elif data_name == 'cite_seq':
-  X, y, encoder = get_citeseq(data_dir + 'cite_seq/CITEseq.h5ad')
+  adata = get_citeseq(data_dir + 'cite_seq/CITEseq.h5ad')
 elif data_name == 'mouse_brain':
-  X, y, encoder = get_mouse_brain(
+  adata = get_mouse_brain(
     data_dir + 'mouse_brain_broad/mouse_brain_all_cells_20200625.h5ad',
     data_dir + 'mouse_brain_broad/snRNA_annotation_astro_subtypes_refined59_20200823.csv',
   )
 elif data_name =='mouse_brain_big':
-  X, y, encoder = get_mouse_brain(
+  adata = get_mouse_brain(
     data_dir + 'mouse_brain_broad/mouse_brain_all_cells_20200625.h5ad',
     data_dir + 'mouse_brain_broad/snRNA_annotation_astro_subtypes_refined59_20200823.csv',
     relabel=False,
   )
 
-num_classes = len(np.unique(y))
+num_classes = len(adata.obs['annotation'].unique())
 
 # The smashpy methods set global seeds that mess with sampling. These seeds are used
 # to stop those methods from using the same global seed over and over.
 random_seeds_queue = SmashPyWrapper.getRandomSeedsQueue(length = len(benchmark_range) * num_times * 5)
 
-input_size = X.shape[1]
+input_size = adata.shape[1]
 
 # Declare models
 unsupervised_mm = MarkerMap.getBenchmarker(
@@ -290,27 +291,27 @@ l1_vae = VAE_l1_diag.getBenchmarker(
 
 results, benchmark_mode, benchmark_range = benchmark(
   {
-    UNSUP_MM: unsupervised_mm,
-    SUP_MM: supervised_mm,
-    MIXED_MM: mixed_mm,
-    BASELINE: RandomBaseline.getBenchmarker(train_kwargs = { 'k': k }),
-    LASSONET: LassoNetWrapper.getBenchmarker(train_kwargs = { 'k': k }),
-    CONCRETE_VAE: concrete_vae,
-    GLOBAL_GATE: global_gate,
-    SMASH_RF: smash_rf,
-    # SMASH_DNN: smash_dnn,
-    # L1_VAE: l1_vae,
-    RANK_CORR: RankCorrWrapper.getBenchmarker(train_kwargs = { 'k': k, 'lamb': 20 }),
-    SCANPY: ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes }),
-    SCANPY + ' overestim_var': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 't-test_overestim_var' }),
-    SCANPY + ' wilcoxon': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon' }),
-    SCANPY + ' wilcoxon tie': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon', 'tie_correct': True }),
-    # SCANPY + ' logreg': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'logreg' }),
-    COSG: COSGWrapper.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes }),
+    # UNSUP_MM: unsupervised_mm,
+    # SUP_MM: supervised_mm,
+    # MIXED_MM: mixed_mm,
+    # BASELINE: RandomBaseline.getBenchmarker(train_kwargs = { 'k': k }),
+    # LASSONET: LassoNetWrapper.getBenchmarker(train_kwargs = { 'k': k }),
+    # CONCRETE_VAE: concrete_vae,
+    # GLOBAL_GATE: global_gate,
+    # SMASH_RF: smash_rf,
+    # # SMASH_DNN: smash_dnn,
+    # # L1_VAE: l1_vae,
+    # RANK_CORR: RankCorrWrapper.getBenchmarker(train_kwargs = { 'k': k, 'lamb': 20 }),
+    # SCANPY: ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes }),
+    # SCANPY + ' overestim_var': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 't-test_overestim_var' }),
+    # SCANPY + ' wilcoxon': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon' }),
+    # SCANPY + ' wilcoxon tie': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'wilcoxon', 'tie_correct': True }),
+    # # SCANPY + ' logreg': ScanpyRankGenes.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes, 'method': 'logreg' }),
+    # COSG: COSGWrapper.getBenchmarker(train_kwargs = { 'k': k, 'num_classes': num_classes }),
+    PERSIST: PersistWrapper.getBenchmarker(train_kwargs = { 'k': k }),
   },
   num_times,
-  X,
-  y,
+  adata,
   save_file=save_file,
   benchmark=benchmark_mode,
   benchmark_range=benchmark_range,

--- a/src/markermap/other_models.py
+++ b/src/markermap/other_models.py
@@ -644,9 +644,10 @@ class PersistWrapper(BenchmarkableModel):
         # We also use the max allowed tolerance to hopeful help with this step
         target = k * 10
         
-        if target < (0.5*X_train.shape[1]): # only try this if we are eliminating at least half the cells
+        if train_kwargs['eliminate_step'] and target < (0.5*X_train.shape[1]): 
+            max_trials = train_kwargs['max_trials'] if 'max_trials' in train_kwargs else 10 # method default
             try:
-                selector.eliminate(target=k*10, max_nepochs=250, tol=0.49)
+                selector.eliminate(target=k*10, max_nepochs=250, tol=0.49, max_trials=max_trials)
             except ValueError:
                 pass
 

--- a/src/markermap/utils.py
+++ b/src/markermap/utils.py
@@ -303,7 +303,7 @@ def benchmark(
                     model_group_by = 'mislabelled_annotation'
                     classifier_train_group_by = group_by
 
-                start_time = time.time_ns()
+                start_time = time.time()
                 markers = model_functional(
                     adata,
                     model_group_by,
@@ -312,7 +312,7 @@ def benchmark(
                     val_indices,
                     k=val,
                 )
-                model_results['time'].append(time.time_ns() - start_time)
+                model_results['time'].append(time.time() - start_time)
 
                 if (eval_type == 'classify'):
                     model_misclass, test_rep, _ = new_model_metrics(

--- a/src/markermap/utils.py
+++ b/src/markermap/utils.py
@@ -166,11 +166,9 @@ def new_model_metrics(train_x, train_y, test_x, test_y, markers = None, model = 
     misclass_rate = 1 - accuracy_score(test_y, pred_y)
     return misclass_rate, test_rep, cm
 
-def recon_model_metrics(train_x, val_x, test_x, markers, model=None):
+def recon_model_metrics(train_x, test_x, markers, model=None):
     if model is None:
         model = LinearRegression()
-
-    train_x = np.concatenate([train_x, val_x], axis=0)
 
     markers_train_x = train_x[:, markers]
     markers_test_x = test_x[:, markers]
@@ -178,9 +176,10 @@ def recon_model_metrics(train_x, val_x, test_x, markers, model=None):
     test_recon_x = reg.predict(markers_test_x)
 
     l2_loss = np.mean((test_x - test_recon_x)**2) 
+    l1_loss = np.abs(test_x - test_recon_x)
     # divide by num cells and num genes so we can compare across datasets
 
-    return l2_loss
+    return l2_loss, l1_loss
 
 def model_variances(path, tries):
     misclass_arr = []
@@ -191,9 +190,11 @@ def model_variances(path, tries):
         weight_f1_arr.append(results[1]['weighted avg']['f1-score'])
     return np.mean(misclass_arr), np.mean(weight_f1_arr), np.std(misclass_arr), np.std(weight_f1_arr)
 
-def mislabel_points(y, mislabel_percent, eligible_indices=None):
+def mislabel_points(adata, mislabel_percent, group_by, eligible_indices=None):
     assert mislabel_percent <= 1.0
     assert mislabel_percent >= 0.0
+
+    y = adata.obs[group_by]
 
     if eligible_indices is None:
         eligible_indices = np.array(range(len(y)))
@@ -210,14 +211,16 @@ def mislabel_points(y, mislabel_percent, eligible_indices=None):
     y_err = y.copy()
     y_err[mislabelled_indices] = mislabels
 
-    return y_err
+    adata.obs['mislabelled_annotations'] = y_err #will this even work
+
+    return adata
 
 def benchmark(
     models,
     num_times,
-    X,
-    y,
+    adata,
     benchmark,
+    group_by = 'annotation',
     train_size = 0.7,
     val_size = 0.1,
     batch_size = 64,
@@ -234,9 +237,9 @@ def benchmark(
         models (dict): maps model labels to a function that runs the model on the data and returns markers
             use model.getBenchmarker() to automatically generate those functions
         num_times (int): number of random data splits to run the model on
-        X (array): Input data
-        y (vector): Output labels
+        adata (AnnData object): input and label data
         benchmark (string): type of benchmarking to do, must be one of {'k', 'label_error', 'label_error_markers_only'}
+        group_by (string): string key for adata.obs[group_by] where the output labels live, defaults to annotation
         train_size (float): 0 to 1, fraction of data for train set, defaults to 0.7
         val_size (float): 0 to 1, fraction of data for validation set, defaults to 0.1
         batch_size (int): defaults to 64
@@ -266,83 +269,62 @@ def benchmark(
     if (benchmark == 'label_error') and (eval_type == 'reconstruct'):
         print(f'WARNING benchmark: benchmark={benchmark} with eval_type={eval_type} doesn\'t have label error')
 
-    results = { 'misclass': {}, 'f1': {} } if (eval_type == 'classify') else { 'l2': {} }
+    results = { 'misclass': {}, 'f1': {} } if (eval_type == 'classify') else { 'l2': {}, 'l1': {} }
     for i in range(num_times):
-        (train_dataloader, val_dataloader, _), (train_indices, val_indices, test_indices) = split_data(
-            X,
-            y,
+        train_indices, val_indices, test_indices = split_data(
+            adata.X,
+            adata.obs['annotation'],
             [train_size, val_size, 1 - train_size - val_size],
-            batch_size=batch_size,
             min_groups=min_groups,
         )
+        train_val_indices = np.concatenate([train_indices, val_indices])
 
-        X_test = X[test_indices,:]
-        y_test = y[test_indices]
+        adata_test = adata[test_indices,:]
 
         for model_label, model_functional in models.items():
 
             model_results = defaultdict(lambda: [])
             for val in benchmark_range:
                 if benchmark == 'k':
-                    markers = model_functional(
-                        X,
-                        y,
-                        train_indices,
-                        val_indices,
-                        train_dataloader,
-                        val_dataloader,
-                        k=val,
-                    )
-                    classifier_y_train = y[np.concatenate([train_indices, val_indices])]
-                elif benchmark == 'label_error' or benchmark == 'label_error_markers_only':
-                    y_err = mislabel_points(y, val, np.concatenate([train_indices, val_indices]))
-                    train_err_dataloader = get_dataloader(
-                        X[train_indices, :],
-                        y_err[train_indices],
-                        batch_size=batch_size,
-                        shuffle=True,
-                    )
-                    val_err_dataloader = get_dataloader(
-                        X[val_indices, :],
-                        y_err[val_indices],
-                        batch_size=batch_size,
-                        shuffle=False,
-                    )
+                    model_group_by = group_by
+                    classifier_train_group_by = group_by
+                elif benchmark == 'label_error':
+                    adata = mislabel_points(adata, group_by, val, train_val_indices)
+                    model_group_by = 'mislabelled_annotation'
+                    classifier_train_group_by = 'mislabelled_annotation'
+                elif benchmark == 'label_error_markers_only':
+                    adata = mislabel_points(adata, group_by, val, train_val_indices)
+                    model_group_by = 'mislabelled_annotation'
+                    classifier_train_group_by = group_by
 
-                    markers = model_functional(
-                        X,
-                        y_err,
-                        train_indices,
-                        val_indices,
-                        train_err_dataloader,
-                        val_err_dataloader,
-                    )
-
-                    if benchmark == 'label_error':
-                        classifier_y_train = y_err[np.concatenate([train_indices, val_indices])]
-                    elif benchmark == 'label_error_markers_only':
-                        classifier_y_train = y[np.concatenate([train_indices, val_indices])]
+                markers = model_functional(
+                    adata,
+                    model_group_by,
+                    train_indices,
+                    val_indices,
+                    k=val,
+                )
 
                 if (eval_type == 'classify'):
                     model_misclass, test_rep, _ = new_model_metrics(
-                        X[np.concatenate([train_indices, val_indices]), :],
-                        classifier_y_train,
-                        X_test,
-                        y_test,
+                        adata[train_val_indices, :].X,
+                        adata[train_val_indices, :].obs[classifier_train_group_by],
+                        adata_test.X,
+                        adata_test.obs[group_by],
                         markers = markers,
                         model=eval_model,
                     )
                     model_results['misclass'].append(model_misclass)
                     model_results['f1'].append(test_rep['weighted avg']['f1-score'])
                 elif (eval_type == 'reconstruct'):
-                    l2_error = recon_model_metrics(
-                        X[train_indices, :],
-                        X[val_indices, :],
-                        X_test,
+                    l2_error, l1_error = recon_model_metrics(
+                        adata[train_val_indices, :].X,
+                        adata_test.X,
                         markers,
                         eval_model,
                     )
                     model_results['l2'].append(l2_error)
+                    model_results['l1'].append(l1_error)
 
             for key,val in model_results.items():
                 val_ndarray = np.array(val).reshape((1,len(val)))
@@ -579,20 +561,6 @@ def process_data(X, Y, filter_data = False):
 
     return np.assarray(aData.X.copy()), Y
 
-def parse_adata(adata):
-    """
-    Split a scanpy adata into X and y, where y is adata.obs['annotation'] converted to numbers using LabelEncoder
-    Args:
-        adata (scanpy adata): The result of something like sc.read_h5ad(), must have .obs['annotation']
-    returns: tuple (X, y, encoder), X data, y as the encoded labels, and the encoder
-    """
-    X = adata.X.copy()
-    labels = adata.obs['annotation'].values
-    encoder = LabelEncoder()
-    encoder.fit(labels)
-    y = encoder.transform(labels)
-    return X, y, encoder
-
 def get_zeisel(file_path, names_key='names0'):
     """
     Get the zeisel data located a file path
@@ -602,11 +570,16 @@ def get_zeisel(file_path, names_key='names0'):
     returns: X data array, y transformed labels, encoder that transformed the labels
     """
     adata = sc.read_h5ad(file_path)
-    adata.obs['names']=adata.obs[names_key]
     adata.obs['annotation'] = adata.obs[names_key]
     adata = adata[adata.obs['annotation'] != '(none)'] # if its names1, there are some unknown cells
 
-    return parse_adata(adata)
+    labels = adata.obs['annotation'].values
+    encoder = LabelEncoder()
+    encoder.fit(labels)
+    y = encoder.transform(labels)
+    adata.obs['annotation'] = y
+
+    return adata
 
 def log_and_normalize(X, recon_X=None):
   """
@@ -672,10 +645,10 @@ def get_paul(housekeeping_bone_marrow_path, house_keeping_HSC_path, smashpy_prep
     for celltype in adata.obs['paul15_clusters'].tolist():
         annotation.append(dict_annotation[celltype])
 
-    adata.obs['annotation'] = annotation
+    adata.obs['annotation'] = pd.Categorical(annotation)
     adata.obs['annotation'] = adata.obs['annotation'].astype('category')
 
-    return parse_adata(adata)
+    return adata
 
 def get_citeseq(file_path):
     """
@@ -685,8 +658,8 @@ def get_citeseq(file_path):
     returns: X data array, y transformed labels, encoder that transformed the labels
     """
     adata = sc.read_h5ad(file_path)
-    adata.obs['annotation'] = adata.obs['names']
-    return parse_adata(adata)
+    adata.obs['annotation'] = adata.obs['names'].astype('category')
+    return adata
 
 def relabel_mouse_labels(label):
     if isinstance(label, str):
@@ -764,7 +737,7 @@ def get_mouse_brain(mouse_brain_path, mouse_brain_labels_path, smashpy_preproces
     """
     adata_snrna_raw = anndata.read_h5ad(mouse_brain_path)
     del adata_snrna_raw.raw
-    adata_snrna_raw = adata_snrna_raw
+    adata_snrna_raw.layers['counts'] = adata_snrna_raw.X # save the counts in a layer
     adata_snrna_raw.X = adata_snrna_raw.X.toarray()
     ## Cell type annotations
     labels = pd.read_csv(mouse_brain_labels_path, index_col=0)
@@ -822,7 +795,7 @@ def get_mouse_brain(mouse_brain_path, mouse_brain_labels_path, smashpy_preproces
         sc.pp.log1p(adata_snrna_raw)
         sc.pp.scale(adata_snrna_raw, max_value=10)
 
-    return parse_adata(adata_snrna_raw)
+    return adata_snrna_raw
 
 def get_dataloader(X, y, batch_size, shuffle, num_workers=0):
     return DataLoader(
@@ -887,8 +860,6 @@ def split_data(
     X, 
     y, 
     size_percents, 
-    batch_size=64, 
-    num_workers=0, 
     seed=None, 
     min_groups=None, 
 ):
@@ -900,7 +871,6 @@ def split_data(
         size_percents (list of floats): the percent sizes of sets of data. If two values are passed then
             two dataloaders and two sets of indices are returned. The size_percents list should add up to 1,
             but the last value is not used, the last set of data will just be the remaining data.
-        batch_size (int): defaults to 64
         num_workers (int): number of cores for multi-threading, defaults to 0 for no multi-threading
         seed (int): defaults to none, set to reproduce experiments with same train/val split
         min_groups (None or list of ints): if not none, should be a list of integers for each set of data.
@@ -908,7 +878,6 @@ def split_data(
     """
     assert np.sum(size_percents) <= 1
     assert len(X) == len(y)
-    assert batch_size > 1
     if min_groups is not None:
         assert len(size_percents) == len(min_groups)
 
@@ -944,7 +913,6 @@ def split_data(
     rng.shuffle(remaining_idxs) # shuffle in place the remaining indices array
 
     # Construct the set dataloaders and indices so that the percents match up, even with min_groups
-    dataloaders = []
     all_indices = []
     set_start = 0
     for i, (percent, min_group) in enumerate(zip(size_percents, min_groups)):
@@ -964,17 +932,11 @@ def split_data(
 
         assert len(indices_list[i]) == (min_group * len(groups)), f'{len(indices_list[i])} {min_group * len(groups)}'
 
-        set_x = X[set_indices, :]
-        set_y = y[set_indices]
-
-        # shuffle the first set, which will likely be the training set and we want to shuffle for batches
-        set_dataloader = get_dataloader(set_x, set_y, batch_size, shuffle=(i==0), num_workers=num_workers)
-        dataloaders.append(set_dataloader)
         all_indices.append(set_indices)
 
         set_start += set_len
 
-    return dataloaders, all_indices
+    return all_indices
 
 #TODO: extract functionality of this and " "_no_test to a helper function, code reuse
 def split_data_into_dataloaders(X, y, train_size, val_size, batch_size = 64, num_workers = 0, seed = None):

--- a/src/markermap/utils.py
+++ b/src/markermap/utils.py
@@ -191,7 +191,7 @@ def model_variances(path, tries):
         weight_f1_arr.append(results[1]['weighted avg']['f1-score'])
     return np.mean(misclass_arr), np.mean(weight_f1_arr), np.std(misclass_arr), np.std(weight_f1_arr)
 
-def mislabel_points(adata, mislabel_percent, group_by, eligible_indices=None):
+def mislabel_points(adata, group_by, mislabel_percent, eligible_indices=None):
     assert mislabel_percent <= 1.0
     assert mislabel_percent >= 0.0
 
@@ -212,7 +212,7 @@ def mislabel_points(adata, mislabel_percent, group_by, eligible_indices=None):
     y_err = y.copy()
     y_err[mislabelled_indices] = mislabels
 
-    adata.obs['mislabelled_annotations'] = y_err #will this even work
+    adata.obs['mislabelled_annotation'] = y_err #will this even work
 
     return adata
 
@@ -310,7 +310,7 @@ def benchmark(
                     batch_size,
                     train_indices,
                     val_indices,
-                    k=val,
+                    k=val if benchmark == 'k' else None,
                 )
                 model_results['time'].append(time.time() - start_time)
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,48 +1,52 @@
 import pytest
 import numpy as np
+import anndata
 
 from markermap.utils import mislabel_points
 
 class TestMislabelPoints:
-  y = np.array([1,1,2,1,0,3,4,5,1,2]) #length 10
+  adata = anndata.AnnData(np.ones((10,10)))
+  adata.obs['annotation'] = np.array([1,1,2,1,0,3,4,5,1,2]) #length 10
   eligible_indices = np.array([0,1,2,4,6,7])
 
   def test_mislabel_percent(self):
     with pytest.raises(AssertionError):
-      mislabel_points(self.y, -1, self.eligible_indices)
+      mislabel_points(self.adata, 'annotation', -1, self.eligible_indices)
 
     with pytest.raises(AssertionError) as e:
-      mislabel_points(self.y, 2, self.eligible_indices)
+      mislabel_points(self.adata, 'annotation', 2, self.eligible_indices)
 
-    mislabel_points(self.y, 0.5, self.eligible_indices)
+    mislabel_points(self.adata, 'annotation', 0.5, self.eligible_indices)
 
   def test_eligible_indices(self):
     bad_eligible_indices = np.array([0,1,2,3,4,5,6,7,8,9,10])
 
     with pytest.raises(AssertionError):
-      mislabel_points(self.y, 0.5, bad_eligible_indices)
+      mislabel_points(self.adata, 'annotation', 0.5, bad_eligible_indices)
 
-    mislabel_points(self.y, 0.2)
+    mislabel_points(self.adata, 'annotation', 0.2)
 
     #test that the unchanged indices are all the same in y and y_err
-    y_err = mislabel_points(self.y, 0.2, self.eligible_indices)
-    unchanged_indices = np.ones(len(self.y))
+    adata_err = mislabel_points(self.adata, 'annotation', 0.2, self.eligible_indices)
+    unchanged_indices = np.ones(len(self.adata))
     unchanged_indices[self.eligible_indices] = False
-    assert ((self.y == y_err)[unchanged_indices.astype(bool)]).all()
+    assert ((self.adata.obs['annotation'] == adata_err.obs['mislabelled_annotation'])[unchanged_indices.astype(bool)]).all()
 
   def test_mismatches_in_bounds(self):
-    y = np.random.randint(0, 10, 1000)
+    adata = anndata.AnnData(np.ones((1000,10)))
+    adata.obs['annotation'] = np.random.randint(0, 10, 1000)
     mislabel_percent = 0.2
 
-    y_err = mislabel_points(y, mislabel_percent)
+    adata_err = mislabel_points(adata, 'annotation', mislabel_percent)
 
-    assert len(y) == len(y_err)
-    mismatches = np.sum(y != y_err)
-    assert mismatches <= int(mislabel_percent * len(y))
-    assert mismatches > int(mislabel_percent * len(y) * 0.5) # technically possible, but v unlikely
+    len_y = len(adata.obs['annotation'])
+    assert len_y == len(adata_err.obs['mislabelled_annotation'])
+    mismatches = np.sum(adata.obs['annotation'] != adata_err.obs['mislabelled_annotation'])
+    assert mismatches <= int(mislabel_percent * len_y)
+    assert mismatches > int(mislabel_percent * len_y * 0.5) # technically possible, but v unlikely
 
   def test_mislabels_from_y(self):
-    y_err = mislabel_points(self.y, 0.5)
-    unique_set = { x for x in np.unique(self.y) }
-    assert np.array([x in unique_set for x in y_err]).all()
+    adata_err = mislabel_points(self.adata, 'annotation', 0.5)
+    unique_set = { x for x in np.unique(self.adata.obs['annotation']) }
+    assert np.array([x in unique_set for x in adata_err.obs['mislabelled_annotation']]).all()
 

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -39,21 +39,21 @@ class TestDataloaders:
     # check that sizes match for even splits
     X = np.arange(20).reshape((10,2))
     y = np.concatenate([np.ones(5), np.zeros(5)])
-    _, (train_indices, test_indices) = split_data(X, y, [0.7, 0.3])
+    train_indices, test_indices = split_data(X, y, [0.7, 0.3])
     assert len(train_indices) == 7
     assert len(test_indices) == 3
 
     # check that sizes match for uneven splits
     X = np.arange(20).reshape((10,2))
     y = np.concatenate([np.ones(5), np.zeros(5)])
-    _, (train_indices, test_indices) = split_data(X, y, [0.65, 0.35])
+    train_indices, test_indices = split_data(X, y, [0.65, 0.35])
     assert len(train_indices) == 6
     assert len(test_indices) == 4
 
     # check that sizes match for uneven splits
     X = np.arange(20).reshape((10,2))
     y = np.concatenate([np.ones(5), np.zeros(5)])
-    _, (train_indices, test_indices) = split_data(X, y, [0.65, 0.35])
+    train_indices, test_indices = split_data(X, y, [0.65, 0.35])
     assert len(train_indices) == 6
     assert len(test_indices) == 4
 
@@ -61,25 +61,25 @@ class TestDataloaders:
     # check that sizes match when using min groups
     X = np.arange(20).reshape((10,2))
     y = np.concatenate([np.ones(5), np.zeros(5)])
-    _, (train_indices, test_indices) = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
+    train_indices, test_indices = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
     assert np.sum(y[train_indices] == 0) > 1 and np.sum(y[train_indices] == 1) > 1
 
     # check that min_groups don't make a set too large
     X = np.arange(20).reshape((10,2))
     y = np.arange(10)
     with pytest.raises(AssertionError):
-      _, (train_indices, test_indices) = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
+      train_indices, test_indices = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
 
     # check that min_group is achievable
     X = np.arange(20).reshape((10,2))
     y = np.concatenate([np.ones(1), np.zeros(9)])
     with pytest.raises(AssertionError):
-      _, (train_indices, test_indices) = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
+      train_indices, test_indices = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
 
     # Check that min_groups is calculated first to ensure that they are all satisfied
     X = np.arange(20).reshape((10,2))
     y = np.concatenate([np.ones(2), np.zeros(8)])
-    _, (train_indices, test_indices) = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
+    train_indices, test_indices = split_data(X, y, [0.7, 0.3], min_groups=[1,1])
     assert np.sum(y[train_indices] == 0) == 6
     assert np.sum(y[train_indices] == 1) == 1
     assert np.sum(y[test_indices] == 0) == 2


### PR DESCRIPTION
## Changes
- add seed to benchmark_k script
- add a PersistWrapper to enable benchmarking against PERSIST
- swap from using X and y numpy arrays to using anndata adata objects. This allows us to pass multiple layers of data to each model, which can then choose what layer they want to use. This is key for PERSIST which runs on binarized counts data
- add a time benchmark that is always calculated
- add an l1 loss metric for reconstruction

## Testing
- [x] run benchmark script with classify
- [x] run benchmark script with reconstruct
- [x] run benchmark script with label_error
- [x] run benchmark script with label_error_markers_only
- [x] pytest

## Doc Changes
- none