### PR TITLE
bug fixes

### DIFF
--- a/scripts/benchmark_k.py
+++ b/scripts/benchmark_k.py
@@ -342,5 +342,5 @@ results, benchmark_mode, benchmark_range = benchmark(
   min_groups=[2,1,1],
 )
 
-plot_mode = 'accuracy' if eval_type == 'classify' else 'recon'
+plot_mode = 'accuracy' if eval_type == 'classify' else 'l2'
 plot_benchmarks(results, benchmark_mode, benchmark_range, mode=plot_mode, show_stdev=True, print_vals=True)


### PR DESCRIPTION
## Changes
- fixed bug with baseline where is wasn't taking the k properly when benchmarking on k
- allow not using the bin layer in persist for testing reasons
- workaround to get "counts" data for zeisel and cite_seq, undo the mean centering and variance normalizing to get back to the log1p values, which can then be binarized. It is not totally reversed because there is also some clipping that happens

## Testing
- ran the scripts